### PR TITLE
Remove target_commitish from goreleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -58,12 +58,6 @@ release:
   # If set to true, will mark the release as not ready for production.
   prerelease: auto
 
-  # Useful if you want to delay the creation of the tag in the remote.
-  # You can create the tag locally, but not push it, and run GoReleaser.
-  # It'll then set the `target_commitish` portion of the GitHub release to the
-  # value of this field.
-  target_commitish: '{{ .Commit }}'
-
 signs:
   - artifacts: checksum
     args:


### PR DESCRIPTION
It is giving an error while uploading the release. Let's remove it for now for the inital release, we can add it back later.