### PR TITLE
Set User-Agent and x-altus-client-app headers for the golang SDK

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,7 +23,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+      - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}'
     goos:
       - freebsd
       - linux

--- a/cdp-sdk-go/cdp/auth.go
+++ b/cdp-sdk-go/cdp/auth.go
@@ -37,8 +37,8 @@ const (
 )
 
 type metastr struct {
-	accessKey  string `json:"access_key_id"`
-	authMethod string `json:"auth_method"`
+	AccessKey  string `json:"access_key_id"`
+	AuthMethod string `json:"auth_method"`
 }
 
 func newMetastr(accessKeyID string) *metastr {

--- a/cdp-sdk-go/cdp/client.go
+++ b/cdp-sdk-go/cdp/client.go
@@ -75,11 +75,7 @@ func NewClient(config *Config) (*Client, error) {
 }
 
 func NewIamClient(config *Config) (*iamclient.Iam, error) {
-	credentials, err := config.GetCredentials()
-	if err != nil {
-		return nil, err
-	}
-	transport, err := GetAPIKeyAuthTransport(config.Context, config.Logger, credentials, config.GetEndpoint("iam", true), config.BaseApiPath, config.GetLocalEnvironment())
+	transport, err := buildClientTransportWithDefaultHttpTransport(config, config.GetEndpoint("iam", true))
 	if err != nil {
 		return nil, err
 	}
@@ -87,11 +83,7 @@ func NewIamClient(config *Config) (*iamclient.Iam, error) {
 }
 
 func NewEnvironmentsClient(config *Config) (*environmentsclient.Environments, error) {
-	credentials, err := config.GetCredentials()
-	if err != nil {
-		return nil, err
-	}
-	transport, err := GetAPIKeyAuthTransport(config.Context, config.Logger, credentials, config.GetEndpoint("environments", false), config.BaseApiPath, config.GetLocalEnvironment())
+	transport, err := buildClientTransportWithDefaultHttpTransport(config, config.GetEndpoint("environments", false))
 	if err != nil {
 		return nil, err
 	}
@@ -99,11 +91,7 @@ func NewEnvironmentsClient(config *Config) (*environmentsclient.Environments, er
 }
 
 func NewDatalakeClient(config *Config) (*datalakeclient.Datalake, error) {
-	credentials, err := config.GetCredentials()
-	if err != nil {
-		return nil, err
-	}
-	transport, err := GetAPIKeyAuthTransport(config.Context, config.Logger, credentials, config.GetEndpoint("datalake", false), config.BaseApiPath, config.GetLocalEnvironment())
+	transport, err := buildClientTransportWithDefaultHttpTransport(config, config.GetEndpoint("datalake", false))
 	if err != nil {
 		return nil, err
 	}
@@ -111,11 +99,7 @@ func NewDatalakeClient(config *Config) (*datalakeclient.Datalake, error) {
 }
 
 func NewDatahubClient(config *Config) (*datahubclient.Datahub, error) {
-	credentials, err := config.GetCredentials()
-	if err != nil {
-		return nil, err
-	}
-	transport, err := GetAPIKeyAuthTransport(config.Context, config.Logger, credentials, config.GetEndpoint("datahub", false), config.BaseApiPath, config.GetLocalEnvironment())
+	transport, err := buildClientTransportWithDefaultHttpTransport(config, config.GetEndpoint("datahub", false))
 	if err != nil {
 		return nil, err
 	}
@@ -123,11 +107,7 @@ func NewDatahubClient(config *Config) (*datahubclient.Datahub, error) {
 }
 
 func NewMlClient(config *Config) (*mlclient.Ml, error) {
-	credentials, err := config.GetCredentials()
-	if err != nil {
-		return nil, err
-	}
-	transport, err := GetAPIKeyAuthTransport(config.Context, config.Logger, credentials, config.GetEndpoint("ml", false), config.BaseApiPath, config.GetLocalEnvironment())
+	transport, err := buildClientTransportWithDefaultHttpTransport(config, config.GetEndpoint("ml", false))
 	if err != nil {
 		return nil, err
 	}
@@ -135,11 +115,7 @@ func NewMlClient(config *Config) (*mlclient.Ml, error) {
 }
 
 func NewDwClient(config *Config) (*dwclient.Dw, error) {
-	credentials, err := config.GetCredentials()
-	if err != nil {
-		return nil, err
-	}
-	transport, err := GetAPIKeyAuthTransport(config.Context, config.Logger, credentials, config.GetEndpoint("dw", false), config.BaseApiPath, config.GetLocalEnvironment())
+	transport, err := buildClientTransportWithDefaultHttpTransport(config, config.GetEndpoint("dw", false))
 	if err != nil {
 		return nil, err
 	}

--- a/cdp-sdk-go/cdp/transport.go
+++ b/cdp-sdk-go/cdp/transport.go
@@ -1,0 +1,156 @@
+// Copyright 2023 Cloudera. All Rights Reserved.
+//
+// This file is licensed under the Apache License Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, either express or implied. Refer to the License for the specific
+// permissions and limitations governing your use of the file.
+
+package cdp
+
+import (
+	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/runtime/client"
+	"net/http"
+	"strings"
+	"time"
+)
+
+var prefixTrim = []string{"http://", "https://"}
+
+type ClientTransport struct {
+	Runtime *client.Runtime
+}
+
+func (t *ClientTransport) Submit(operation *runtime.ClientOperation) (interface{}, error) {
+	response, err := t.Runtime.Submit(operation)
+	return response, err
+}
+
+func getDefaultTransport(config *Config) (http.RoundTripper, error) {
+	tlsClientOptions := client.TLSClientOptions{
+		InsecureSkipVerify: config.GetLocalEnvironment(),
+	}
+	cfg, err := client.TLSClientAuth(tlsClientOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	return &http.Transport{TLSClientConfig: cfg}, nil
+}
+
+func buildClientTransportWithDefaultHttpTransport(config *Config, endpoint string) (*ClientTransport, error) {
+	roundTripper, err := getDefaultTransport(config)
+	if err != nil {
+		return nil, err
+	}
+	return buildClientTransport(config, endpoint, roundTripper)
+}
+
+func buildClientTransport(config *Config, endpoint string, roundTripper http.RoundTripper) (*ClientTransport, error) {
+	credentials, err := config.GetCredentials()
+	if err != nil {
+		return nil, err
+	}
+	baseApiPath := config.BaseApiPath
+	address, basePath := cutAndTrimAddress(endpoint)
+
+	rtChain := buildInterceptorChain(config, roundTripper)
+
+	transport := &ClientTransport{client.NewWithClient(address, basePath+baseApiPath, []string{"https"}, &http.Client{Transport: rtChain})}
+	// TODO: Look into whether this should be done as a RoundTripper in the chain to unify the request interceptors.
+	transport.Runtime.DefaultAuthentication = requestSigWriter(config.Context, config.Logger, baseApiPath, credentials)
+
+	return transport, nil
+}
+
+// TODO: this should use a proper URL parser
+func cutAndTrimAddress(address string) (string, string) {
+	for _, v := range prefixTrim {
+		address = strings.TrimPrefix(address, v)
+	}
+	address = strings.TrimRight(address, "/ ")
+	basePath := ""
+	slashIndex := strings.Index(address, "/")
+	if slashIndex != -1 {
+		basePath = address[slashIndex:]
+		address = address[0:slashIndex]
+	}
+	return address, basePath
+}
+
+// buildInterceptorChain builds a chain of RoundTripper objects that modify the request and delegates
+// to the next one in the chain.
+func buildInterceptorChain(config *Config, rt0 http.RoundTripper) http.RoundTripper {
+	rt1 := buildRequestHeadersRoundTripper(config, rt0)
+	rt2 := buildLoggingRoundTripper(config, rt1)
+	return rt2
+}
+
+func buildLoggingRoundTripper(config *Config, delegate http.RoundTripper) *LoggingRoundTripper {
+	return &LoggingRoundTripper{
+		DelegatingRoundTripper: DelegatingRoundTripper{delegate: delegate},
+		logger:                 config.Logger,
+	}
+}
+
+func buildRequestHeadersRoundTripper(config *Config, delegate http.RoundTripper) *RequestHeadersRoundTripper {
+	reqHeadersRT := &RequestHeadersRoundTripper{
+		DelegatingRoundTripper: DelegatingRoundTripper{delegate: delegate},
+	}
+	reqHeadersRT.AddHeader("User-Agent", config.GetUserAgentOrDefault())
+	reqHeadersRT.AddHeader("x-altus-client-app", config.ClientApplicationName)
+	return reqHeadersRT
+}
+
+type DelegatingRoundTripper struct {
+	delegate http.RoundTripper
+}
+
+type LoggingRoundTripper struct {
+	DelegatingRoundTripper
+	logger Logger
+}
+
+func (t *LoggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	startTime := time.Now()
+	resp, err := t.delegate.RoundTrip(req)
+	duration := time.Since(startTime)
+
+	if err != nil {
+		t.logger.Debugf(req.Context(), "HTTP Request URL=%s method=%s error=%s resp=%v durationMs=%d", req.URL, req.Method, resp, err.Error(), duration)
+	} else {
+		t.logger.Debugf(req.Context(), "HTTP Request URL=%s method=%s status=%d resp=%v durationMs=%d", req.URL, req.Method, resp.StatusCode, resp, duration)
+	}
+
+	return resp, err
+}
+
+// RequestHeadersRoundTripper sets the User-Agent and other custom headers
+// see https://github.com/go-swagger/go-swagger/blob/701e7f3ee85df9d47fcf639dd7a279f7ab6d94d7/docs/faq/faq_client.md?plain=1#L28
+type RequestHeadersRoundTripper struct {
+	DelegatingRoundTripper
+	headers map[string]string
+}
+
+func (r *RequestHeadersRoundTripper) AddHeader(key, value string) {
+	if key == "" || value == "" {
+		return
+	}
+	if r.headers == nil {
+		r.headers = make(map[string]string)
+	}
+	r.headers[key] = value
+}
+
+func (r *RequestHeadersRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if r.headers != nil {
+		for k, v := range r.headers {
+			req.Header.Set(k, v)
+		}
+	}
+
+	return r.delegate.RoundTrip(req)
+}

--- a/cdp-sdk-go/cdp/transport_test.go
+++ b/cdp-sdk-go/cdp/transport_test.go
@@ -1,0 +1,158 @@
+// Copyright 2023 Cloudera. All Rights Reserved.
+//
+// This file is licensed under the Apache License Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, either express or implied. Refer to the License for the specific
+// permissions and limitations governing your use of the file.
+
+package cdp
+
+import (
+	"context"
+	"github.com/go-openapi/errors"
+	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/strfmt"
+	"net/http"
+	"regexp"
+	"testing"
+)
+
+var (
+	testCredentials = Credentials{
+		AccessKeyId: "auth_test",
+		PrivateKey:  "37yMdtdkJANPn62X5KDKKI3iv5hbAAKvqxHdgIj22bo=",
+	}
+	testEndpoint = "https://api.us-west-1.cdp.cloudera.com"
+)
+
+type mockRoundTripper struct {
+	req *http.Request
+}
+
+func (t *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.req = req
+	return nil, errors.NotImplemented("mock")
+}
+
+func getTestOperation() *runtime.ClientOperation {
+	return &runtime.ClientOperation{
+		ID:                 "testApi",
+		Method:             "POST",
+		PathPattern:        "/api/v1/someservice/testApi",
+		ProducesMediaTypes: []string{"application/json"},
+		ConsumesMediaTypes: []string{"application/json"},
+		Schemes:            []string{"https"},
+		Reader: runtime.ClientResponseReaderFunc(func(runtime.ClientResponse, runtime.Consumer) (interface{}, error) {
+			return nil, nil
+		}),
+
+		Params: runtime.ClientRequestWriterFunc(func(req runtime.ClientRequest, reg strfmt.Registry) error {
+			return req.SetBodyParam("test body")
+		}),
+		Context: context.Background(),
+	}
+}
+
+func getTestConfig() *Config {
+	config := NewConfig()
+	config.WithContext(context.Background())
+	config.WithCredentials(&testCredentials)
+	config.WithLogger(NewDefaultLogger())
+	config.WithVersion("0.1.0")
+	config.initConfig()
+	return config
+}
+
+func TestDefaultUserAgent(t *testing.T) {
+	config := getTestConfig()
+
+	mockRoundTripper := mockRoundTripper{}
+	transport, err := buildClientTransport(config, testEndpoint, &mockRoundTripper)
+	if err != nil {
+		t.Fatalf("Failed to get transport: %v", err)
+	}
+
+	_, err = transport.Submit(getTestOperation())
+
+	userAgent := mockRoundTripper.req.UserAgent()
+
+	r, _ := regexp.Compile(`^CDPSDK_GO/.+ Go/.+ .+_.+$`)
+	if !r.MatchString(userAgent) {
+		t.Fatalf("Failed to match the User-Agent regex: %v", userAgent)
+	}
+
+	if err == nil {
+		t.Fatalf("Should have failed with err from mock.")
+	}
+}
+
+func TestCustomUserAgent(t *testing.T) {
+	config := getTestConfig()
+	config.WithUserAgent("test-user-agent")
+
+	mockRoundTripper := mockRoundTripper{}
+	transport, err := buildClientTransport(config, testEndpoint, &mockRoundTripper)
+	if err != nil {
+		t.Fatalf("Failed to get transport: %v", err)
+	}
+
+	_, err = transport.Submit(getTestOperation())
+
+	userAgent := mockRoundTripper.req.UserAgent()
+
+	if userAgent != "test-user-agent" {
+		t.Fatalf("Failed to match the User-Agent: %v", userAgent)
+	}
+
+	if err == nil {
+		t.Fatalf("Should have failed with err from mock.")
+	}
+}
+
+func TestDefaultClientApplicationName(t *testing.T) {
+	config := getTestConfig()
+
+	mockRoundTripper := mockRoundTripper{}
+	transport, err := buildClientTransport(config, testEndpoint, &mockRoundTripper)
+	if err != nil {
+		t.Fatalf("Failed to get transport: %v", err)
+	}
+
+	_, err = transport.Submit(getTestOperation())
+
+	clientAppName := mockRoundTripper.req.Header.Get("x-altus-client-app")
+
+	if clientAppName != "" {
+		t.Fatalf("x-altus-client-app header should not have been set: %v", clientAppName)
+	}
+
+	if err == nil {
+		t.Fatalf("Should have failed with err from mock.")
+	}
+}
+
+func TestCustomClientApplicationName(t *testing.T) {
+	config := getTestConfig()
+	config.WithClientApplicationName("test-client-application-name")
+
+	mockRoundTripper := mockRoundTripper{}
+	transport, err := buildClientTransport(config, testEndpoint, &mockRoundTripper)
+	if err != nil {
+		t.Fatalf("Failed to get transport: %v", err)
+	}
+
+	_, err = transport.Submit(getTestOperation())
+
+	clientAppName := mockRoundTripper.req.Header.Get("x-altus-client-app")
+
+	if clientAppName != "test-client-application-name" {
+		t.Fatalf("x-altus-client-app header does not match: %v", clientAppName)
+	}
+
+	if err == nil {
+		t.Fatalf("Should have failed with err from mock.")
+	}
+}

--- a/cdp-sdk-go/cdp/transport_test.go
+++ b/cdp-sdk-go/cdp/transport_test.go
@@ -12,12 +12,13 @@ package cdp
 
 import (
 	"context"
-	"github.com/go-openapi/errors"
-	"github.com/go-openapi/runtime"
-	"github.com/go-openapi/strfmt"
 	"net/http"
 	"regexp"
 	"testing"
+
+	"github.com/go-openapi/errors"
+	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/strfmt"
 )
 
 var (
@@ -62,7 +63,7 @@ func getTestConfig() *Config {
 	config.WithCredentials(&testCredentials)
 	config.WithLogger(NewDefaultLogger())
 	config.WithVersion("0.1.0")
-	config.initConfig()
+	config.credentialsProvider = &StaticCredentialsProvider{&testCredentials}
 	return config
 }
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -113,7 +113,7 @@ func (p *CdpProvider) Configure(ctx context.Context, req provider.ConfigureReque
 	resp.Diagnostics.Append(diags...)
 
 	// Create a new CDP client using the configuration values
-	client, err := cdp.NewClient(getCdpConfig(ctx, data, p.version, req.TerraformVersion))
+	client, err := cdp.NewClient(getCdpConfig(ctx, &data, p.version, req.TerraformVersion))
 
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -163,7 +163,7 @@ func getOrDefaultBoolFromEnv(val basetypes.BoolValue, envVars ...string) bool {
 	return false
 }
 
-func getCdpConfig(ctx context.Context, data CdpProviderModel, version string, terraformVersion string) *cdp.Config {
+func getCdpConfig(ctx context.Context, data *CdpProviderModel, version string, terraformVersion string) *cdp.Config {
 	tflog.Info(ctx, "Setting up CDP config")
 
 	accessKeyId := getOrDefaultFromEnv(data.CdpAccessKeyId, "CDP_ACCESS_KEY_ID")

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -11,8 +11,11 @@
 package provider
 
 import (
+	"context"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"regexp"
 	"testing"
 )
 
@@ -28,4 +31,25 @@ func testAccPreCheck(t *testing.T) {
 	// You can add code here to run prior to any test case execution, for example assertions
 	// about the appropriate environment variables being set are common to see in a pre-check
 	// function.
+}
+
+func TestProviderOverridesUserAgent(t *testing.T) {
+	model := CdpProviderModel{
+		CdpAccessKeyId:           types.StringValue("cdp-access-key"),
+		CdpPrivateKey:            types.StringValue("cdp-private-key"),
+		Profile:                  types.StringValue("profile"),
+		AltusEndpointUrl:         types.StringValue("altus-endpoint-url"),
+		CdpEndpointUrl:           types.StringValue("cdp-endpoint-url"),
+		CdpConfigFile:            types.StringValue("cdp-config-file"),
+		CdpSharedCredentialsFile: types.StringValue("cdp-shared-credentials-file"),
+		LocalEnvironment:         types.BoolValue(false),
+	}
+
+	config := getCdpConfig(context.Background(), model, "0.1.0", "v1.4.2")
+	userAgent := config.GetUserAgentOrDefault()
+
+	r, _ := regexp.Compile(`^CDPTFPROVIDER/.+ Terraform/.+ Go/.+ .+_.+$`)
+	if !r.MatchString(userAgent) {
+		t.Fatalf("Failed to match the User-Agent regex: %v", userAgent)
+	}
 }

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -33,8 +33,8 @@ func testAccPreCheck(t *testing.T) {
 	// function.
 }
 
-func TestProviderOverridesUserAgent(t *testing.T) {
-	model := CdpProviderModel{
+func createCdpProviderModel() *CdpProviderModel {
+	return &CdpProviderModel{
 		CdpAccessKeyId:           types.StringValue("cdp-access-key"),
 		CdpPrivateKey:            types.StringValue("cdp-private-key"),
 		Profile:                  types.StringValue("profile"),
@@ -44,6 +44,10 @@ func TestProviderOverridesUserAgent(t *testing.T) {
 		CdpSharedCredentialsFile: types.StringValue("cdp-shared-credentials-file"),
 		LocalEnvironment:         types.BoolValue(false),
 	}
+}
+
+func TestProviderOverridesUserAgent(t *testing.T) {
+	model := createCdpProviderModel()
 
 	config := getCdpConfig(context.Background(), model, "0.1.0", "v1.4.2")
 	userAgent := config.GetUserAgentOrDefault()
@@ -51,5 +55,16 @@ func TestProviderOverridesUserAgent(t *testing.T) {
 	r, _ := regexp.Compile(`^CDPTFPROVIDER/.+ Terraform/.+ Go/.+ .+_.+$`)
 	if !r.MatchString(userAgent) {
 		t.Fatalf("Failed to match the User-Agent regex: %v", userAgent)
+	}
+}
+
+func TestProviderClientApplicationName(t *testing.T) {
+	model := createCdpProviderModel()
+
+	config := getCdpConfig(context.Background(), model, "0.1.0", "v1.4.2")
+	clientApplicationName := config.ClientApplicationName
+
+	if clientApplicationName != "terraform-provider-cdp" {
+		t.Fatalf("Terraform provider should have set client application name. Got: %v", clientApplicationName)
 	}
 }


### PR DESCRIPTION
"I've extended the SDK to be able to accept a custom User-Agent header as well as the header for
x-altus-client-app which is defined in the Java SDK (not sure whether it is used or not). The
user agent header is set to follow the pattern for CDP CLI and Java SDK.

Further, the terraform provider now overrides the user agent from the SDK with a Terraform specific
one. We intend to split the cdp-sdk-go into its own repository so once that happens, the user agent
from the go SDK vs the user agent from the terraform provider should be tracked differently.

"This commit does not contain secrets"

Testing done:

new unit tests"