### PR TITLE
Add a pre commit test github workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,74 @@
+name: Test
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    strategy:
+      matrix:
+        go-version: [ '1.20', '1.19', '1.18' ]
+
+    steps:
+    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+    - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Run linters
+      uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # v3.6.0
+      with:
+        version: latest
+
+    - name: Generate
+      run: make generate
+
+    - name: Confirm no diff
+      run: |
+        git diff --compact-summary --exit-code || \
+          (echo "*** Unexpected differences after code generation. Run 'make generate' and commit."; exit 1)
+
+    - name: Build
+      run: make build
+
+  test:
+    name: 'Terraform Provider Acceptance Tests (OS: ${{ matrix.os }} / TF: ${{ matrix.terraform }})'
+    needs: build
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - windows-latest
+          - ubuntu-latest
+        terraform:
+          - '1.0.*'
+          - '1.1.*'
+          - '1.2.*'
+          - '1.3.*'
+          - '1.4.*'
+
+    steps:
+    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+    - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+      with:
+        go-version-file: 'go.mod'
+
+    - name: Setup Terraform ${{ matrix.terraform }}
+      uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+      with:
+        terraform_version: ${{ matrix.terraform }}
+        terraform_wrapper: false
+
+    - name: Run acceptance test
+      run: make testacc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
       uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # v3.6.0
       with:
         version: latest
+        args: --timeout 3m
 
     - name: Generate
       run: make generate

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,12 @@ testacc:
 	TF_ACC=1 go test -count=1 -parallel=4 -timeout 10m -v ./...
 
 # Build main binary
-main: generate fmt vet
+main: build
+
+
+build: generate fmt vet
 	go build $(GO_FLAGS) ./
+
 
 install: main
 	go install .

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ check-go:
 ifndef GOPATH
 	$(error GOPATH not defined, please define GOPATH. Run "go help gopath" to learn more about GOPATH)
 endif
-.PHONY: check-go docs
 
 # Run tests
 test: generate fmt vet
@@ -34,10 +33,12 @@ testacc:
 # Build main binary
 main: build
 
-
 build: generate fmt vet
 	go build $(GO_FLAGS) ./
 
+# See https://golangci-lint.run/
+lint:
+	golangci-lint run
 
 install: main
 	go install .
@@ -49,17 +50,14 @@ install-terraformrc:
 # Make a release
 release: test testacc docs
 	@goreleaser release --clean
-.PHONY: release
 
 # Make a local snapshot release
 release-snapshot: test
 	@goreleaser release --snapshot --clean
-.PHONY: release-snapshot
 
 clean:
 	rm -f terraform-provider-cdp
 	rm -rf dist
-.PHONY: clean
 
 # Run go fmt against code
 fmt:
@@ -86,4 +84,5 @@ mod-tidy:
 # Deploy
 deploy: all
 	cp terraform-provider-cdp ~/.terraform.d/plugins/terraform-provider-cdp
-.PHONY: deploy
+
+.PHONY: all check-go docs deploy test mod-tidy generate vet fmt clean release release-snapshot install-terraformrc install main build

--- a/cdp-sdk-go/cdp/config.go
+++ b/cdp-sdk-go/cdp/config.go
@@ -297,9 +297,8 @@ func (config *Config) convertProfileMap(properties map[string]map[string]string)
 		} else if profile == "default" {
 			// Default is special, and considered a profile without having to write [profile default] as a section.
 			ret[profile] = profileData
-		} else {
-			// silently ignore. We do not yet support config keys that are not profiles. Can be added later.
 		}
+		// else silently ignore. We do not yet support config keys that are not profiles. Can be added later.
 	}
 
 	return ret

--- a/main.go
+++ b/main.go
@@ -24,8 +24,8 @@ var (
 	// to appropriate values for the compiled binary.
 	// https://goreleaser.com/cookbooks/using-main.version/
 	version = "dev"
-	commit  = "none"
-	date    = "unknown"
+	commit  = "none"    //nolint:all
+	date    = "unknown" //nolint:all
 )
 
 func main() {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -146,18 +146,21 @@ func getOrDefaultFromEnv(val basetypes.StringValue, envVars ...string) string {
 	return ""
 }
 
-func getOrDefaultBoolFromEnv(val basetypes.BoolValue, envVars ...string) bool {
+func getOrDefaultBoolFromEnv(ctx context.Context, val basetypes.BoolValue, envVars ...string) bool {
 	if !val.IsNull() {
 		return val.ValueBool()
 	}
 
 	for _, envVar := range envVars {
 		env, ok := os.LookupEnv(envVar)
-		if !ok {
-			return false
+		if ok {
+			boolVal, err := strconv.ParseBool(env)
+			if err != nil {
+				tflog.Warn(ctx, fmt.Sprintf("Error parsing boolean: %v", env))
+				return false
+			}
+			return boolVal
 		}
-		boolVal, _ := strconv.ParseBool(env)
-		return boolVal
 	}
 	return false
 }
@@ -172,7 +175,7 @@ func getCdpConfig(ctx context.Context, data CdpProviderModel) *cdp.Config {
 	cdpEndpointUrl := getOrDefaultFromEnv(data.CdpEndpointUrl, "CDP_ENDPOINT_URL")
 	cdpConfigFile := getOrDefaultFromEnv(data.CdpConfigFile, "CDP_CONFIG_FILE")
 	cdpSharedCredentialsFile := getOrDefaultFromEnv(data.CdpSharedCredentialsFile, "CDP_SHARED_CREDENTIALS_FILE")
-	localEnvironment := getOrDefaultBoolFromEnv(data.LocalEnvironment, "LOCAL_ENVIRONMENT")
+	localEnvironment := getOrDefaultBoolFromEnv(ctx, data.LocalEnvironment, "LOCAL_ENVIRONMENT")
 
 	config := cdp.NewConfig()
 	config.WithContext(ctx)

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -20,10 +20,13 @@ import (
 // acceptance testing. The factory function will be invoked for every Terraform
 // CLI command executed to create a provider server to which the CLI can
 // reattach.
+//
+//nolint:all
 var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
 	"cdp": providerserver.NewProtocol6WithError(New("test")()),
 }
 
+//nolint:all
 func testAccPreCheck(t *testing.T) {
 	// You can add code here to run prior to any test case execution, for example assertions
 	// about the appropriate environment variables being set are common to see in a pre-check

--- a/resources/datalake/resource_aws_datalake.go
+++ b/resources/datalake/resource_aws_datalake.go
@@ -15,17 +15,18 @@ import (
 	"log"
 	"time"
 
-	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/cdp"
-	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/datalake/client"
-	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/datalake/client/operations"
-	datalakemodels "github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/datalake/models"
-	"github.com/cloudera/terraform-provider-cdp/utils"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/cdp"
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/datalake/client"
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/datalake/client/operations"
+	datalakemodels "github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/datalake/models"
+	"github.com/cloudera/terraform-provider-cdp/utils"
 )
 
 var (

--- a/resources/environments/resource_aws_credential.go
+++ b/resources/environments/resource_aws_credential.go
@@ -12,8 +12,6 @@ package environments
 
 import (
 	"context"
-	"strings"
-
 	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/cdp"
 	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/client/operations"
 	environmentsmodels "github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/models"
@@ -193,12 +191,4 @@ func (r *awsCredentialResource) Delete(ctx context.Context, req resource.DeleteR
 		)
 		return
 	}
-}
-
-func isNotAuthorizedError(err error) bool {
-	if d, ok := err.(*operations.CreateAWSEnvironmentDefault); ok && d.GetPayload() != nil {
-		return d.GetPayload().Code == "INVALID_ARGUMENT" &&
-			strings.Contains(d.GetPayload().Message, "You are not authorized")
-	}
-	return false
 }

--- a/utils/copyright_test.go
+++ b/utils/copyright_test.go
@@ -23,16 +23,7 @@ var (
 	skippedPrefixes = []string{".", "_"}
 	skippedPaths    = []string{"/testdata/", "/gen/", "/dist/"}
 
-	copyrightRe = regexp.MustCompile(`[[:graph:]]+ Copyright \d{4} Cloudera\. All Rights Reserved\.
-[[:graph:]]+
-[[:graph:]]+ This file is licensed under the Apache License Version 2\.0 \(the "License"\)\.
-[[:graph:]]+ You may not use this file except in compliance with the License.
-[[:graph:]]+ You may obtain a copy of the License at http:\/\/www\.apache\.org\/licenses\/LICENSE-2\.0\.
-[[:graph:]]+
-[[:graph:]]+ This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
-[[:graph:]]+ OF ANY KIND, either express or implied. Refer to the License for the specific
-[[:graph:]]+ permissions and limitations governing your use of the file\.
-`)
+	copyrightRe = regexp.MustCompile(`[[:graph:]]+ Copyright \d{4} Cloudera\. All Rights Reserved\.\s+[[:graph:]]+\s+[[:graph:]]+ This file is licensed under the Apache License Version 2\.0 \(the "License"\)\.\s+[[:graph:]]+ You may not use this file except in compliance with the License.\s+[[:graph:]]+ You may obtain a copy of the License at http:\/\/www\.apache\.org\/licenses\/LICENSE-2\.0\.\s+[[:graph:]]+\s+[[:graph:]]+ This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS\s+[[:graph:]]+ OF ANY KIND, either express or implied. Refer to the License for the specific\s+[[:graph:]]+ permissions and limitations governing your use of the file\.`)
 )
 
 func TestAllLicenseHeaders(t *testing.T) {

--- a/utils/slice.go
+++ b/utils/slice.go
@@ -13,7 +13,7 @@ package utils
 import "strings"
 
 func ContainsAsSubstring(slice []string, element string) bool {
-	if slice != nil && len(slice) > 0 {
+	if len(slice) > 0 {
 		for _, e := range slice {
 			if strings.Contains(element, e) {
 				return true
@@ -24,7 +24,7 @@ func ContainsAsSubstring(slice []string, element string) bool {
 }
 
 func ContainsEitherSubstring(slice []string, elements []string) bool {
-	if slice != nil && len(slice) > 0 && elements != nil && len(elements) > 0 {
+	if len(slice) > 0 && len(elements) > 0 {
 		for _, e := range slice {
 			for _, substring := range elements {
 				if strings.Contains(e, substring) {


### PR DESCRIPTION
I added a github workflow that uses github actions to run the build and the unit and terraform acceptance tests for every pull request. 

The contents of the github workflow mimics the https://github.com/hashicorp/terraform-provider-scaffolding-framework/tree/main/.github/workflows as well as other similar providers from Hashicorp. This seems like a good start for the initial test, but we will add more workflows (especially for releasing later).

In the process I had to: 
 - Fix lint errors (1 actual bug)
 - Ignore some lint issues
 - Add build and lint targets to the Makefile
 - Remove deprecated / unused code
 - Fix the copy-right header tests on Windows