### PR TITLE
Run Terraform fmt for examples files during the build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,11 @@ jobs:
     - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
       with:
         go-version: ${{ matrix.go-version }}
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+      with:
+        terraform_version: '1.4.*'
+        terraform_wrapper: false
 
     - name: Run linters
       uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # v3.6.0

--- a/Makefile
+++ b/Makefile
@@ -60,9 +60,11 @@ clean:
 	rm -rf dist
 
 # Run go fmt against code
-fmt:
+fmt: terraform-fmt
 	go fmt ./...
-	# terraform fmt -recursive ./examples/  TODO: Re-enable this in CDPCP-9174
+
+terraform-fmt:
+	terraform fmt -recursive ./examples/
 
 # Run go vet against code
 vet:

--- a/docs/resources/environments_aws_environment.md
+++ b/docs/resources/environments_aws_environment.md
@@ -23,9 +23,9 @@ The environment is a logical entity that represents the association of your user
 # permissions and limitations governing your use of the file.
 
 resource "cdp_environments_aws_credential" "example" {
-  credential_name        = "example-cdp-aws-credential"
-  role_arn    = "arn:aws:iam::11111111111:role/example-cross-account-role"
-  description = "Example AWS Credentials"
+  credential_name = "example-cdp-aws-credential"
+  role_arn        = "arn:aws:iam::11111111111:role/example-cross-account-role"
+  description     = "Example AWS Credentials"
 }
 
 resource "cdp_environments_aws_environment" "example" {

--- a/docs/resources/environments_gcp_credential.md
+++ b/docs/resources/environments_gcp_credential.md
@@ -32,9 +32,9 @@ terraform {
 }
 
 resource "cdp_environments_gcp_credential" "example" {
-  credential_name     = "cdp-gcp-credential"
-  credential_key      = "<BASE64 content>"
-  description         = "Example GCP Credentials"
+  credential_name = "cdp-gcp-credential"
+  credential_key  = "<BASE64 content>"
+  description     = "Example GCP Credentials"
 }
 
 output "credential_name" {
@@ -42,7 +42,7 @@ output "credential_name" {
 }
 
 output "credential_key" {
-  value = cdp_environments_gcp_credential.example.credential_key
+  value     = cdp_environments_gcp_credential.example.credential_key
   sensitive = true
 }
 ```

--- a/examples/resources/cdp_environments_aws_environment/resource.tf
+++ b/examples/resources/cdp_environments_aws_environment/resource.tf
@@ -9,9 +9,9 @@
 # permissions and limitations governing your use of the file.
 
 resource "cdp_environments_aws_credential" "example" {
-  credential_name        = "example-cdp-aws-credential"
-  role_arn    = "arn:aws:iam::11111111111:role/example-cross-account-role"
-  description = "Example AWS Credentials"
+  credential_name = "example-cdp-aws-credential"
+  role_arn        = "arn:aws:iam::11111111111:role/example-cross-account-role"
+  description     = "Example AWS Credentials"
 }
 
 resource "cdp_environments_aws_environment" "example" {

--- a/examples/resources/cdp_environments_gcp_credential/resource.tf
+++ b/examples/resources/cdp_environments_gcp_credential/resource.tf
@@ -17,9 +17,9 @@ terraform {
 }
 
 resource "cdp_environments_gcp_credential" "example" {
-  credential_name     = "cdp-gcp-credential"
-  credential_key      = "<BASE64 content>"
-  description         = "Example GCP Credentials"
+  credential_name = "cdp-gcp-credential"
+  credential_key  = "<BASE64 content>"
+  description     = "Example GCP Credentials"
 }
 
 output "credential_name" {
@@ -27,6 +27,6 @@ output "credential_name" {
 }
 
 output "credential_key" {
-  value = cdp_environments_gcp_credential.example.credential_key
+  value     = cdp_environments_gcp_credential.example.credential_key
   sensitive = true
 }


### PR DESCRIPTION
We disabled running `terraform fmt` on the `examples/` directory since the CI builds did not have terraform in the container / VM image. Now that we are building with github, we can enable that again both for local builds as well as builds for github checks. The only downside is that all local builds will require terraform to be installed.