### PR TITLE
Fixed issue caused by config names that have uppercase characters (#37)

### DIFF
--- a/cdp-sdk-go/cdp/config_test.go
+++ b/cdp-sdk-go/cdp/config_test.go
@@ -11,41 +11,68 @@
 package cdp
 
 import (
-	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/common"
 	"os"
 	"testing"
+
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/common"
 )
+
+func unsetEnvs(keys ...string) {
+	for _, key := range keys {
+		os.Unsetenv(key)
+	}
+}
 
 func TestGetCdpProfileFromConfig(t *testing.T) {
 	os.Setenv(cdpProfileEnvVar, "foo")
 	os.Setenv(cdpDefaultProfileEnvVar, "bar")
+	defer unsetEnvs(cdpProfileEnvVar, cdpDefaultProfileEnvVar)
 	config := Config{
 		Profile: "baz",
 	}
-	common.AssertEquals(t, "baz", config.GetCdpProfile())
+	profile, err := config.GetCdpProfile()
+	if err != nil {
+		t.Fatalf("Error getting the config value: %v", err)
+	}
+	common.AssertEquals(t, "baz", profile)
 }
 
 func TestGetCdpProfileFromEnv(t *testing.T) {
 	os.Setenv(cdpProfileEnvVar, "foo")
 	os.Setenv(cdpDefaultProfileEnvVar, "bar")
+	defer unsetEnvs(cdpProfileEnvVar, cdpDefaultProfileEnvVar)
 	config := Config{
 		Profile: "",
 	}
-	common.AssertEquals(t, "bar", config.GetCdpProfile())
+	profile, err := config.GetCdpProfile()
+	if err != nil {
+		t.Fatalf("Error getting the config value: %v", err)
+	}
+	common.AssertEquals(t, "bar", profile)
 }
 
 func TestGetCdpProfileFromEnv2(t *testing.T) {
 	os.Setenv(cdpProfileEnvVar, "")
 	os.Setenv(cdpDefaultProfileEnvVar, "bar")
+	defer unsetEnvs(cdpProfileEnvVar, cdpDefaultProfileEnvVar)
 	config := Config{}
-	common.AssertEquals(t, "bar", config.GetCdpProfile())
+	profile, err := config.GetCdpProfile()
+	if err != nil {
+		t.Fatalf("Error getting the config value: %v", err)
+	}
+	common.AssertEquals(t, "bar", profile)
 }
 
 func TestGetCdpProfileFromDefault(t *testing.T) {
 	os.Setenv(cdpProfileEnvVar, "")
 	os.Setenv(cdpDefaultProfileEnvVar, "")
+	defer unsetEnvs(cdpProfileEnvVar, cdpDefaultProfileEnvVar)
 	config := Config{}
-	common.AssertEquals(t, cdpDefaultProfile, config.GetCdpProfile())
+	profile, err := config.GetCdpProfile()
+	if err != nil {
+		t.Fatalf("Error getting the config value: %v", err)
+	}
+	common.AssertEquals(t, cdpDefaultProfile, profile)
 }
 
 func TestGetCredentialsNotFound(t *testing.T) {
@@ -54,6 +81,7 @@ func TestGetCredentialsNotFound(t *testing.T) {
 	os.Setenv(CdpPrivateKeyEnvVar, "")
 	os.Setenv(cdpProfileEnvVar, "")
 	os.Setenv(cdpDefaultProfileEnvVar, "")
+	defer unsetEnvs(CdpAccessKeyIdEnvVar, CdpPrivateKeyEnvVar, cdpProfileEnvVar, cdpDefaultProfileEnvVar)
 
 	path := "testdata/test-credentials"
 	profile := "profile_non_existing"
@@ -78,6 +106,7 @@ func TestGetCdpCredentials(t *testing.T) {
 	os.Setenv(CdpPrivateKeyEnvVar, "value-from-env")
 	os.Setenv(cdpProfileEnvVar, "")
 	os.Setenv(cdpDefaultProfileEnvVar, "")
+	defer unsetEnvs(CdpAccessKeyIdEnvVar, CdpPrivateKeyEnvVar, cdpProfileEnvVar, cdpDefaultProfileEnvVar)
 
 	path := "testdata/test-credentials"
 	profile := "file_cdp_credentials_provider_profile"
@@ -130,6 +159,7 @@ func TestGetCdpCredentials(t *testing.T) {
 
 func TestLoadConfigFileNotFound(t *testing.T) {
 	os.Setenv("CDP_CONFIG_FILE", "")
+	defer unsetEnvs("CDP_CONFIG_FILE")
 	config := Config{
 		ConfigFile: "testdata/non-existent-file",
 	}
@@ -142,6 +172,7 @@ func TestLoadConfigFileNotFound(t *testing.T) {
 
 func TestLoadConfigFile(t *testing.T) {
 	os.Setenv("CDP_CONFIG_FILE", "")
+	defer unsetEnvs("CDP_CONFIG_FILE")
 	config := Config{
 		ConfigFile: "testdata/test-config",
 	}
@@ -149,11 +180,16 @@ func TestLoadConfigFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	common.AssertEquals(t, "value1", config.GetCdpApiEndpoint())
+	endpoint, err := config.GetCdpApiEndpoint()
+	if err != nil {
+		t.Fatalf("Error getting the config value: %v", err)
+	}
+	common.AssertEquals(t, "value1", endpoint)
 }
 
 func TestLoadConfigFileFromEnv(t *testing.T) {
 	os.Setenv("CDP_CONFIG_FILE", "testdata/test-config")
+	defer unsetEnvs("CDP_CONFIG_FILE")
 	config := Config{
 		ConfigFile: "testdata/test-config",
 	}
@@ -161,10 +197,61 @@ func TestLoadConfigFileFromEnv(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	common.AssertEquals(t, "value1", config.GetCdpApiEndpoint())
+	endpoint, err := config.GetCdpApiEndpoint()
+	if err != nil {
+		t.Fatalf("Error getting the config value: %v", err)
+	}
+	common.AssertEquals(t, "value1", endpoint)
 }
 
-func TestGetCdpApiEndpointWithProfile(t *testing.T) {
+func TestGetCdpProfileCaseSensitivity(t *testing.T) {
+	// We support case sensitive section names, but case insensitive option names
+	config := Config{
+		ConfigFile: "testdata/test-config",
+		Profile:    "UPPER_CASE_PROFILE",
+	}
+	err := config.loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	endpoint, err := config.GetCdpApiEndpoint()
+	if err != nil {
+		t.Fatalf("Error getting the config value: %v", err)
+	}
+	common.AssertEquals(t, "value6", endpoint)
+}
+
+func TestGetCdpRegionFromConfig(t *testing.T) {
+	config := Config{
+		CdpRegion: "foo",
+	}
+	os.Setenv("CDP_REGION", "bar")
+	defer unsetEnvs("CDP_REGION")
+	region, err := config.GetCdpRegion()
+	if err != nil {
+		t.Fatalf("Error getting the config value: %v", err)
+	}
+	common.AssertEquals(t, "foo", region)
+}
+
+func TestGetCdpRegionFromEnv(t *testing.T) {
+	config := Config{}
+	os.Setenv("CDP_REGION", "foo")
+	defer unsetEnvs("CDP_REGION")
+	region, err := config.GetCdpRegion()
+	if err != nil {
+		t.Fatalf("Error getting the config value: %v", err)
+	}
+	common.AssertEquals(t, "foo", region)
+	cdpEndpoint, err := config.GetCdpApiEndpoint()
+	if err != nil {
+		t.Fatalf("Error getting the config value: %v", err)
+	}
+	common.AssertEquals(t, "https://api.foo.cdp.cloudera.com/", cdpEndpoint)
+}
+
+func TestGetCdpRegionFromConfigFile(t *testing.T) {
 	config := Config{
 		Profile:    "foo",
 		ConfigFile: "testdata/test-config",
@@ -173,7 +260,72 @@ func TestGetCdpApiEndpointWithProfile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	common.AssertEquals(t, "value3", config.GetCdpApiEndpoint())
+	region, err := config.GetCdpRegion()
+	if err != nil {
+		t.Fatalf("Error getting the config value: %v", err)
+	}
+	common.AssertEquals(t, "value5", region)
+}
+
+func TestGetCdpRegionFromDefault(t *testing.T) {
+	config := Config{}
+	region, err := config.GetCdpRegion()
+	if err != nil {
+		t.Fatalf("Error getting the config value: %v", err)
+	}
+	common.AssertEquals(t, defaultCdpRegion, region)
+}
+
+func TestGetEndpointsWithProfile(t *testing.T) {
+	config := Config{
+		Profile:    "foo",
+		ConfigFile: "testdata/test-config",
+	}
+	err := config.loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cdpEndpoint, err := config.GetCdpApiEndpoint()
+	if err != nil {
+		t.Fatalf("Error getting the config value: %v", err)
+	}
+	altusEndpoint, err := config.GetAltusApiEndpoint()
+	if err != nil {
+		t.Fatalf("Error getting the config value: %v", err)
+	}
+	iamEndpoint, err := config.GetEndpoint("iam", true)
+	if err != nil {
+		t.Fatalf("Error getting the endpoint: %v", err)
+	}
+	common.AssertEquals(t, "value3", cdpEndpoint)
+	common.AssertEquals(t, "value4%s", altusEndpoint)
+	common.AssertEquals(t, "value4iam", iamEndpoint)
+}
+
+func TestGetEndpointsWithRegionInProfile(t *testing.T) {
+	config := Config{
+		Profile:    "bar",
+		ConfigFile: "testdata/test-config",
+	}
+	err := config.loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cdpEndpoint, err := config.GetCdpApiEndpoint()
+	if err != nil {
+		t.Fatalf("Error getting the config value: %v", err)
+	}
+	altusEndpoint, err := config.GetAltusApiEndpoint()
+	if err != nil {
+		t.Fatalf("Error getting the config value: %v", err)
+	}
+	iamEndpoint, err := config.GetEndpoint("iam", true)
+	if err != nil {
+		t.Fatalf("Error getting the endpoint: %v", err)
+	}
+	common.AssertEquals(t, "https://api.value6.cdp.cloudera.com/", cdpEndpoint)
+	common.AssertEquals(t, "https://api.value6.cdp.cloudera.com/", altusEndpoint)
+	common.AssertEquals(t, "https://api.value6.cdp.cloudera.com/", iamEndpoint)
 }
 
 func TestDefaultEndpoints(t *testing.T) {
@@ -185,10 +337,107 @@ func TestDefaultEndpoints(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if config.GetCdpApiEndpoint() != defaultCdpApiEndpointUrl {
-		t.Errorf("Expected default CDP endpoint to be %s", defaultCdpApiEndpointUrl)
+	cdpEndpoint, err := config.GetCdpApiEndpoint()
+	if err != nil {
+		t.Fatalf("Error getting the config value: %v", err)
 	}
-	if config.GetAltusApiEndpoint() != defaultAltusApiEndpointUrl {
-		t.Errorf("Expected default Altus endpoint to be %s", defaultAltusApiEndpointUrl)
+	altusEndpoint, err := config.GetAltusApiEndpoint()
+	if err != nil {
+		t.Fatalf("Error getting the config value: %v", err)
 	}
+	iamEndpoint, err := config.GetEndpoint("iam", true)
+	if err != nil {
+		t.Fatalf("Error getting the endpoint: %v", err)
+	}
+	common.AssertEquals(t, "https://api.us-west-1.cdp.cloudera.com/", cdpEndpoint)
+	common.AssertEquals(t, "https://%sapi.us-west-1.altus.cloudera.com/", altusEndpoint)
+	common.AssertEquals(t, "https://iamapi.us-west-1.altus.cloudera.com/", iamEndpoint)
+}
+
+func TestGetEndpointsWithRegionUsWest1(t *testing.T) {
+	config := Config{
+		CdpRegion: RegionUsWest1,
+	}
+	cdpEndpoint, err := config.GetCdpApiEndpoint()
+	if err != nil {
+		t.Fatalf("Error getting the config value: %v", err)
+	}
+	altusEndpoint, err := config.GetAltusApiEndpoint()
+	if err != nil {
+		t.Fatalf("Error getting the config value: %v", err)
+	}
+	iamEndpoint, err := config.GetEndpoint("iam", true)
+	if err != nil {
+		t.Fatalf("Error getting the endpoint: %v", err)
+	}
+
+	common.AssertEquals(t, "https://api.us-west-1.cdp.cloudera.com/", cdpEndpoint)
+	common.AssertEquals(t, "https://%sapi.us-west-1.altus.cloudera.com/", altusEndpoint)
+	common.AssertEquals(t, "https://iamapi.us-west-1.altus.cloudera.com/", iamEndpoint)
+}
+
+func TestGetEndpointsWithRegionEu1(t *testing.T) {
+	config := Config{
+		CdpRegion: RegionEu1,
+	}
+	cdpEndpoint, err := config.GetCdpApiEndpoint()
+	if err != nil {
+		t.Fatalf("Error getting the config value: %v", err)
+	}
+	altusEndpoint, err := config.GetAltusApiEndpoint()
+	if err != nil {
+		t.Fatalf("Error getting the config value: %v", err)
+	}
+	iamEndpoint, err := config.GetEndpoint("iam", true)
+	if err != nil {
+		t.Fatalf("Error getting the endpoint: %v", err)
+	}
+
+	common.AssertEquals(t, "https://api.eu-1.cdp.cloudera.com/", cdpEndpoint)
+	common.AssertEquals(t, "https://api.eu-1.cdp.cloudera.com/", altusEndpoint)
+	common.AssertEquals(t, "https://api.eu-1.cdp.cloudera.com/", iamEndpoint)
+}
+
+func TestGetEndpointsWithRegionAp1(t *testing.T) {
+	config := Config{
+		CdpRegion: RegionAp1,
+	}
+	cdpEndpoint, err := config.GetCdpApiEndpoint()
+	if err != nil {
+		t.Fatalf("Error getting the config value: %v", err)
+	}
+	altusEndpoint, err := config.GetAltusApiEndpoint()
+	if err != nil {
+		t.Fatalf("Error getting the config value: %v", err)
+	}
+	iamEndpoint, err := config.GetEndpoint("iam", true)
+	if err != nil {
+		t.Fatalf("Error getting the endpoint: %v", err)
+	}
+
+	common.AssertEquals(t, "https://api.ap-1.cdp.cloudera.com/", cdpEndpoint)
+	common.AssertEquals(t, "https://api.ap-1.cdp.cloudera.com/", altusEndpoint)
+	common.AssertEquals(t, "https://api.ap-1.cdp.cloudera.com/", iamEndpoint)
+}
+
+func TestGetEndpointsWithRegionUsg1(t *testing.T) {
+	config := Config{
+		CdpRegion: RegionUsg1,
+	}
+	cdpEndpoint, err := config.GetCdpApiEndpoint()
+	if err != nil {
+		t.Fatalf("Error getting the config value: %v", err)
+	}
+	altusEndpoint, err := config.GetAltusApiEndpoint()
+	if err != nil {
+		t.Fatalf("Error getting the config value: %v", err)
+	}
+	iamEndpoint, err := config.GetEndpoint("iam", true)
+	if err != nil {
+		t.Fatalf("Error getting the endpoint: %v", err)
+	}
+
+	common.AssertEquals(t, "https://api.usg-1.cdp.clouderagovt.com/", cdpEndpoint)
+	common.AssertEquals(t, "https://api.usg-1.cdp.clouderagovt.com/", altusEndpoint)
+	common.AssertEquals(t, "https://api.usg-1.cdp.clouderagovt.com/", iamEndpoint)
 }

--- a/cdp-sdk-go/cdp/credentials.go
+++ b/cdp-sdk-go/cdp/credentials.go
@@ -12,9 +12,10 @@ package cdp
 
 import (
 	"fmt"
-	"gopkg.in/ini.v1"
 	"os"
 	"strings"
+
+	"gopkg.in/ini.v1"
 )
 
 const (
@@ -140,7 +141,11 @@ func (p *ChainCredentialsProvider) GetCredentials() (*Credentials, error) {
 // maps to a set of key value pairs.
 func rawParseConfigFile(path string) (map[string]map[string]string, error) {
 	properties := make(map[string]map[string]string)
-	cfg, err := ini.InsensitiveLoad(path)
+	cfg, err := ini.LoadSources(
+		ini.LoadOptions{
+			InsensitiveKeys: true,
+		},
+		path)
 	if err != nil {
 		return nil, err
 	}

--- a/cdp-sdk-go/cdp/credentials_test.go
+++ b/cdp-sdk-go/cdp/credentials_test.go
@@ -11,9 +11,10 @@
 package cdp
 
 import (
-	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/common"
 	"os"
 	"testing"
+
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/common"
 )
 
 func TestEnvCdpCredentialsProviderWithUnsetEnv(t *testing.T) {
@@ -73,8 +74,9 @@ func TestEnvCdpCredentialsProviderWithAccessKeyAndPrivateKey(t *testing.T) {
 	}
 }
 
-func TestLoadCdpCredentialsFile(t *testing.T) {
+func TestRawParseConfigFile(t *testing.T) {
 	expected := map[string]map[string]string{
+		"DEFAULT": {},
 		"default": {
 			"cdp_access_key_id": "value1",
 			"cdp_private_key":   "value2",
@@ -91,6 +93,10 @@ func TestLoadCdpCredentialsFile(t *testing.T) {
 		"file_cdp_credentials_provider_profile": {
 			"cdp_access_key_id": "value-from-file",
 			"cdp_private_key":   "value-from-file",
+		},
+		"UPPER_CASE_PROFILE": {
+			"cdp_access_key_id": "value8",
+			"cdp_private_key":   "value9",
 		},
 	}
 
@@ -175,5 +181,20 @@ func TestConfigCdpCredentialsProviderNonEmptyConfig(t *testing.T) {
 	}
 	if res.AccessKeyId != "foo" && res.PrivateKey != "bar" {
 		t.Errorf("Wrong values returned as CDP credentials: accesKey: %s privateKey:%s", res.AccessKeyId, res.PrivateKey)
+	}
+}
+
+func TestFileCdpCredentialsProviderCaseSensitivity(t *testing.T) {
+	path := "testdata/test-credentials"
+	profile := "UPPER_CASE_PROFILE"
+	cdpCredentials, err := GetCredentialsFromFileProvider(t, path, profile)
+	if err != nil || cdpCredentials == nil {
+		t.Fatal(err)
+	}
+	if cdpCredentials.AccessKeyId != "value8" {
+		t.Errorf("%s should have been %s for the profile: %s", cdpAccessKeyIdPropertyKey, "value6", profile)
+	}
+	if cdpCredentials.PrivateKey != "value9" {
+		t.Errorf("%s should have been %s for the profile: %s", cdpPrivateKeyPropertyKey, "value7", profile)
 	}
 }

--- a/cdp-sdk-go/cdp/testdata/test-config
+++ b/cdp-sdk-go/cdp/testdata/test-config
@@ -6,3 +6,5 @@ endpoint_url=value2
 cdp_endpoint_url=value3
 endpoint_url=value4
 
+[profile UPPER_CASE_PROFILE]
+CDP_ENDPOINT_URL=value6

--- a/cdp-sdk-go/cdp/testdata/test-credentials
+++ b/cdp-sdk-go/cdp/testdata/test-credentials
@@ -14,3 +14,7 @@ cdp_private_key=value7
 [file_cdp_credentials_provider_profile]
 cdp_access_key_id=value-from-file
 cdp_private_key=value-from-file
+
+[UPPER_CASE_PROFILE]
+CDP_ACCESS_KEY_ID=value8
+CDP_PRIVATE_KEY=value9


### PR DESCRIPTION
* Fixed issue caused by config names that have uppercase characters

* Fixed unit test and add more test cases

We decided to follow the Python CDP CLI semantics for case sensitivity to be compatible between the two tools and least surprises to the end user. Python INI file parsing defaults to case sensitive section names, but case insensitive option names. We do the same in the go SDK.

This commit adds some more unit tests.

---------