### PR TITLE
CDPCP-10147 Add the first tf acceptance test for aws credentials

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ endif
 
 # Run tests
 test: generate fmt vet
-	go test $(GO_FLAGS) ./...
+	go test $(GO_FLAGS) $(TESTARGS) ./...
 
 # Run tests with coverage
 test-with-coverage: generate fmt vet
@@ -28,7 +28,7 @@ test-with-coverage: generate fmt vet
 
 # Run terraform provider acceptance tests
 testacc:
-	TF_ACC=1 go test -count=1 -parallel=4 -timeout 10m -v ./...
+	TF_ACC=1 go test ./... $(GO_FLAGS) $(TESTARGS) -count=1 -parallel=4 -timeout 10m -v
 
 # Build main binary
 main: build

--- a/cdp-sdk-go/cdp/config.go
+++ b/cdp-sdk-go/cdp/config.go
@@ -39,9 +39,10 @@ const (
 	// when reading the credentials file. Overrides cdpDefaultProfile.
 	cdpDefaultProfileEnvVar = "CDP_DEFAULT_PROFILE"
 
+	// CdpProfileEnvVar is the environment variable to configure the CDP profile
 	// Python client uses both CDP_PROFILE and CDP_DEFAULT_PROFILE
 	// versus Java SDK uses CDP_DEFAULT_PROFILE
-	cdpProfileEnvVar = "CDP_PROFILE"
+	CdpProfileEnvVar = "CDP_PROFILE"
 
 	// Name of the profile in the users credentials file to read.
 	cdpDefaultProfile = "default"
@@ -218,7 +219,7 @@ var propertySchemas = map[string]propertySchema{
 		defaultFunc: defaultCdpCredentialsFile,
 	},
 	"cdp_profile": {
-		envVars:     []string{cdpDefaultProfileEnvVar, cdpProfileEnvVar},
+		envVars:     []string{cdpDefaultProfileEnvVar, CdpProfileEnvVar},
 		configKey:   "",
 		defaultFunc: stringSupplier(cdpDefaultProfile),
 	},

--- a/cdp-sdk-go/cdp/config_test.go
+++ b/cdp-sdk-go/cdp/config_test.go
@@ -24,9 +24,9 @@ func unsetEnvs(keys ...string) {
 }
 
 func TestGetCdpProfileFromConfig(t *testing.T) {
-	os.Setenv(cdpProfileEnvVar, "foo")
+	os.Setenv(CdpProfileEnvVar, "foo")
 	os.Setenv(cdpDefaultProfileEnvVar, "bar")
-	defer unsetEnvs(cdpProfileEnvVar, cdpDefaultProfileEnvVar)
+	defer unsetEnvs(CdpProfileEnvVar, cdpDefaultProfileEnvVar)
 	config := Config{
 		Profile: "baz",
 	}
@@ -38,9 +38,9 @@ func TestGetCdpProfileFromConfig(t *testing.T) {
 }
 
 func TestGetCdpProfileFromEnv(t *testing.T) {
-	os.Setenv(cdpProfileEnvVar, "foo")
+	os.Setenv(CdpProfileEnvVar, "foo")
 	os.Setenv(cdpDefaultProfileEnvVar, "bar")
-	defer unsetEnvs(cdpProfileEnvVar, cdpDefaultProfileEnvVar)
+	defer unsetEnvs(CdpProfileEnvVar, cdpDefaultProfileEnvVar)
 	config := Config{
 		Profile: "",
 	}
@@ -52,9 +52,9 @@ func TestGetCdpProfileFromEnv(t *testing.T) {
 }
 
 func TestGetCdpProfileFromEnv2(t *testing.T) {
-	os.Setenv(cdpProfileEnvVar, "")
+	os.Setenv(CdpProfileEnvVar, "")
 	os.Setenv(cdpDefaultProfileEnvVar, "bar")
-	defer unsetEnvs(cdpProfileEnvVar, cdpDefaultProfileEnvVar)
+	defer unsetEnvs(CdpProfileEnvVar, cdpDefaultProfileEnvVar)
 	config := Config{}
 	profile, err := config.GetCdpProfile()
 	if err != nil {
@@ -64,9 +64,9 @@ func TestGetCdpProfileFromEnv2(t *testing.T) {
 }
 
 func TestGetCdpProfileFromDefault(t *testing.T) {
-	os.Setenv(cdpProfileEnvVar, "")
+	os.Setenv(CdpProfileEnvVar, "")
 	os.Setenv(cdpDefaultProfileEnvVar, "")
-	defer unsetEnvs(cdpProfileEnvVar, cdpDefaultProfileEnvVar)
+	defer unsetEnvs(CdpProfileEnvVar, cdpDefaultProfileEnvVar)
 	config := Config{}
 	profile, err := config.GetCdpProfile()
 	if err != nil {
@@ -79,9 +79,9 @@ func TestGetCredentialsNotFound(t *testing.T) {
 	// empty env vars.
 	os.Setenv(CdpAccessKeyIdEnvVar, "")
 	os.Setenv(CdpPrivateKeyEnvVar, "")
-	os.Setenv(cdpProfileEnvVar, "")
+	os.Setenv(CdpProfileEnvVar, "")
 	os.Setenv(cdpDefaultProfileEnvVar, "")
-	defer unsetEnvs(CdpAccessKeyIdEnvVar, CdpPrivateKeyEnvVar, cdpProfileEnvVar, cdpDefaultProfileEnvVar)
+	defer unsetEnvs(CdpAccessKeyIdEnvVar, CdpPrivateKeyEnvVar, CdpProfileEnvVar, cdpDefaultProfileEnvVar)
 
 	path := "testdata/test-credentials"
 	profile := "profile_non_existing"
@@ -104,9 +104,9 @@ func TestGetCdpCredentials(t *testing.T) {
 	// empty env vars.
 	os.Setenv(CdpAccessKeyIdEnvVar, "value-from-env")
 	os.Setenv(CdpPrivateKeyEnvVar, "value-from-env")
-	os.Setenv(cdpProfileEnvVar, "")
+	os.Setenv(CdpProfileEnvVar, "")
 	os.Setenv(cdpDefaultProfileEnvVar, "")
-	defer unsetEnvs(CdpAccessKeyIdEnvVar, CdpPrivateKeyEnvVar, cdpProfileEnvVar, cdpDefaultProfileEnvVar)
+	defer unsetEnvs(CdpAccessKeyIdEnvVar, CdpPrivateKeyEnvVar, CdpProfileEnvVar, cdpDefaultProfileEnvVar)
 
 	path := "testdata/test-credentials"
 	profile := "file_cdp_credentials_provider_profile"

--- a/cdpacctest/acctest.go
+++ b/cdpacctest/acctest.go
@@ -1,0 +1,123 @@
+// Copyright 2023 Cloudera. All Rights Reserved.
+//
+// This file is licensed under the Apache License Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, either express or implied. Refer to the License for the specific
+// permissions and limitations governing your use of the file.
+
+package cdpacctest
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"sync"
+	"testing"
+
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/cdp"
+	"github.com/cloudera/terraform-provider-cdp/provider"
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/pkg/errors"
+)
+
+const (
+	ResourcePrefix = "tf-acc-test"
+)
+
+var TestAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
+	"cdp": providerserver.NewProtocol6WithError(provider.New("test")()),
+}
+
+var (
+	preCheckOnce sync.Once
+	crnPattern   = regexp.MustCompile("^crn:([\\w\\-]+):(\\w+):([\\w\\-]+):([\\w\\-]+):(\\w+):(\\S+)$")
+
+	AwsExternalProvider = map[string]resource.ExternalProvider{
+		"aws": {
+			Source:            "hashicorp/aws",
+			VersionConstraint: "~> 5.0",
+		},
+	}
+	HttpExternalProvider = map[string]resource.ExternalProvider{
+		"http": {
+			Source:            "hashicorp/http",
+			VersionConstraint: "~> 3.4",
+		},
+	}
+
+	cdpClientOnce sync.Once
+	cdpClient     *cdp.Client
+)
+
+//nolint:all
+func PreCheck(t *testing.T) {
+	preCheckOnce.Do(func() {
+		if os.Getenv(cdp.CdpProfileEnvVar) == "" && os.Getenv(cdp.CdpAccessKeyIdEnvVar) == "" {
+			t.Fatalf("Terraform acceptance testing requires either %s or %s environment variables to be set", cdp.CdpProfileEnvVar, cdp.CdpAccessKeyIdEnvVar)
+		}
+
+		if os.Getenv(cdp.CdpAccessKeyIdEnvVar) != "" {
+			if _, ok := os.LookupEnv(cdp.CdpPrivateKeyEnvVar); !ok {
+				t.Fatalf("Environment variable %s should be set together with %s", cdp.CdpPrivateKeyEnvVar, cdp.CdpAccessKeyIdEnvVar)
+			}
+		}
+
+		// TODO: check whether AWS, Azure or GCP is configured.
+	})
+}
+
+func ConcatExternalProviders(providerMaps ...map[string]resource.ExternalProvider) map[string]resource.ExternalProvider {
+	result := make(map[string]resource.ExternalProvider)
+
+	for _, p := range providerMaps {
+		for k, v := range p {
+			result[k] = v
+		}
+	}
+
+	return result
+}
+
+func TestAccCdpProviderConfig() string {
+	return `
+provider "cdp" {
+}
+`
+}
+
+func TestAccAwsProviderConfig() string {
+	return `
+provider "aws" {
+}
+`
+}
+
+// CheckCrn Checks whether the value is set and is a properly formatted CRN
+func CheckCrn(value string) error {
+	if value == "" {
+		return errors.New("Expected CRN to be set")
+	}
+
+	if !crnPattern.MatchString(value) {
+		return errors.New(fmt.Sprintf("Provided value does not match expected CRN format: %s", value))
+	}
+
+	return nil
+}
+
+func GetCdpClientForAccTest() *cdp.Client {
+	cdpClientOnce.Do(func() {
+		config := cdp.NewConfig()
+		var err error
+		cdpClient, err = cdp.NewClient(config)
+		if err != nil {
+			panic(fmt.Sprintf("error while creating CDP Client: %v", err))
+		}
+	})
+	return cdpClient
+}

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -15,27 +15,8 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
-
-// testAccProtoV6ProviderFactories are used to instantiate a provider during
-// acceptance testing. The factory function will be invoked for every Terraform
-// CLI command executed to create a provider server to which the CLI can
-// reattach.
-//
-//nolint:all
-var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
-	"cdp": providerserver.NewProtocol6WithError(New("test")()),
-}
-
-//nolint:all
-func testAccPreCheck(t *testing.T) {
-	// You can add code here to run prior to any test case execution, for example assertions
-	// about the appropriate environment variables being set are common to see in a pre-check
-	// function.
-}
 
 func createCdpProviderModel() *CdpProviderModel {
 	return &CdpProviderModel{

--- a/resources/environments/data_source_aws_credential_prerequisites.go
+++ b/resources/environments/data_source_aws_credential_prerequisites.go
@@ -39,6 +39,7 @@ type awsCredentialPrerequisitesDataSource struct {
 
 // awsCredentialPrerequisitesDataSourceModel maps the data source schema data.
 type awsCredentialPrerequisitesDataSourceModel struct {
+	ID         types.String `tfsdk:"id"`
 	AccountID  types.String `tfsdk:"account_id"`
 	ExternalID types.String `tfsdk:"external_id"`
 }
@@ -56,6 +57,9 @@ func (d *awsCredentialPrerequisitesDataSource) Schema(_ context.Context, _ datas
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "This data source is used to get information required to set up a delegated access role in AWS that can be used to create a CDP credential.",
 		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
 			"account_id": schema.StringAttribute{
 				MarkdownDescription: "The AWS account ID of the identity used by CDP when assuming a delegated access role associated with a CDP credential.",
 				Computed:            true,
@@ -106,6 +110,7 @@ func (d *awsCredentialPrerequisitesDataSource) Read(ctx context.Context, req dat
 
 	data.AccountID = types.StringValue(prerequisites.AccountID)
 	data.ExternalID = types.StringValue(*prerequisites.Aws.ExternalID)
+	data.ID = types.StringValue(prerequisites.AccountID + ":" + *prerequisites.Aws.ExternalID)
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/resources/environments/resource_aws_credential_test.go
+++ b/resources/environments/resource_aws_credential_test.go
@@ -1,0 +1,243 @@
+// Copyright 2023 Cloudera. All Rights Reserved.
+//
+// This file is licensed under the Apache License Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, either express or implied. Refer to the License for the specific
+// permissions and limitations governing your use of the file.
+
+package environments_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/models"
+	"github.com/cloudera/terraform-provider-cdp/cdpacctest"
+	"github.com/cloudera/terraform-provider-cdp/resources/environments"
+	"github.com/cloudera/terraform-provider-cdp/utils"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAwsCredential_basic(t *testing.T) {
+	rName := acctest.RandomWithPrefix(cdpacctest.ResourcePrefix)
+	resourceName := "cdp_environments_aws_credential.test"
+	var credential models.Credential
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { cdpacctest.PreCheck(t) },
+		ProtoV6ProviderFactories: cdpacctest.TestAccProtoV6ProviderFactories,
+		ExternalProviders: cdpacctest.ConcatExternalProviders(
+			cdpacctest.HttpExternalProvider,
+			cdpacctest.AwsExternalProvider,
+		),
+		CheckDestroy: testAccCheckAwsCredentialDestroy,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: utils.Concat(
+					cdpacctest.TestAccCdpProviderConfig(),
+					cdpacctest.TestAccAwsProviderConfig(),
+					testAccAwsCrossAccountRoleConfig(rName),
+					testAccAwsCredentialConfig(rName, "aws_iam_role.cdp_cross_account_role.arn")),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", rName),
+					resource.TestCheckResourceAttr(resourceName, "credential_name", rName),
+					resource.TestCheckResourceAttrWith(resourceName, "crn", cdpacctest.CheckCrn),
+					testAccCheckAwsCredentialExists(resourceName, &credential),
+					testAccCheckAwsCredentialValues(&credential, rName, ""),
+					resource.TestCheckResourceAttrWith(resourceName, "role_arn", func(value string) error {
+						return utils.CheckStringEquals("AwsCredentialProperties.RoleArn", credential.AwsCredentialProperties.RoleArn, value)
+					}),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func TestAccAwsCredential_withDescription(t *testing.T) {
+	rName := acctest.RandomWithPrefix(cdpacctest.ResourcePrefix)
+	resourceName := "cdp_environments_aws_credential.test"
+	var credential models.Credential
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { cdpacctest.PreCheck(t) },
+		ProtoV6ProviderFactories: cdpacctest.TestAccProtoV6ProviderFactories,
+		ExternalProviders: cdpacctest.ConcatExternalProviders(
+			cdpacctest.HttpExternalProvider,
+			cdpacctest.AwsExternalProvider,
+		),
+		CheckDestroy: testAccCheckAwsCredentialDestroy,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: utils.Concat(
+					cdpacctest.TestAccCdpProviderConfig(),
+					cdpacctest.TestAccAwsProviderConfig(),
+					testAccAwsCrossAccountRoleConfig(rName),
+					testAccAwsCredentialConfigWithDescription(rName, "aws_iam_role.cdp_cross_account_role.arn", rName)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", rName),
+					resource.TestCheckResourceAttr(resourceName, "credential_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", rName),
+					resource.TestCheckResourceAttrWith(resourceName, "crn", cdpacctest.CheckCrn),
+					testAccCheckAwsCredentialExists(resourceName, &credential),
+					testAccCheckAwsCredentialValues(&credential, rName, rName),
+					resource.TestCheckResourceAttrWith(resourceName, "role_arn", func(value string) error {
+						return utils.CheckStringEquals("AwsCredentialProperties.RoleArn", credential.AwsCredentialProperties.RoleArn, value)
+					}),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func testAccAwsCredentialConfig(rName string, roleArn string) string {
+	return fmt.Sprintf(`
+resource "cdp_environments_aws_credential" "test" {
+  credential_name = %[1]q
+  role_arn        = %[2]s
+}
+`, rName, roleArn)
+}
+
+func testAccAwsCredentialConfigWithDescription(rName string, roleArn string, description string) string {
+	return fmt.Sprintf(`
+resource "cdp_environments_aws_credential" "test" {
+  credential_name = %[1]q
+  role_arn        = %[2]s
+  description     = %[3]q
+}
+`, rName, roleArn, description)
+}
+
+func testAccAwsCrossAccountRoleConfig(rName string) string {
+	return fmt.Sprintf(`
+data "cdp_environments_aws_credential_prerequisites" "credential_prerequisites" {}
+
+# TODO: Replace this with minimal policy?
+data "http" "cdp_cross_account_account_policy_doc" {
+  url = "https://raw.githubusercontent.com/hortonworks/cloudbreak/master/cloud-aws-common/src/main/resources/definitions/aws-cb-policy.json"
+}
+
+data "aws_iam_policy_document" "cdp_cross_account_assume_role_policy_doc" {
+  version = "2012-10-17"
+
+  statement {
+    actions = ["sts:AssumeRole"]
+    effect  = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.cdp_environments_aws_credential_prerequisites.credential_prerequisites.account_id}:root"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "sts:ExternalId"
+
+      values = ["${data.cdp_environments_aws_credential_prerequisites.credential_prerequisites.external_id}"]
+    }
+  }
+}
+
+resource "aws_iam_policy" "cdp_cross_account_policy" {
+  name = %[1]q
+  policy = data.http.cdp_cross_account_account_policy_doc.response_body
+}
+
+resource "aws_iam_role" "cdp_cross_account_role" {
+  name = %[1]q
+  assume_role_policy = data.aws_iam_policy_document.cdp_cross_account_assume_role_policy_doc.json
+}
+
+resource "aws_iam_role_policy_attachment" "cdp_cross_account_policy_attachment" {
+  role = aws_iam_role.cdp_cross_account_role.name
+  policy_arn = aws_iam_policy.cdp_cross_account_policy.arn
+}
+`, rName)
+}
+
+// testAccCheckAwsCredentialExists queries the API and retrieves the matching AwsCredential via the passed in pointer.
+func testAccCheckAwsCredentialExists(resourceName string, credential *models.Credential) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// find the corresponding state object
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		// TODO: I could not find a way to get the reference to the provider in the new framework. If possible we should
+		// avoid creating a new CDP client
+		cdpClient := cdpacctest.GetCdpClientForAccTest()
+
+		c, err := environments.FindCredentialByName(context.Background(), cdpClient, rs.Primary.ID)
+		if err != nil {
+			return nil
+		}
+
+		if c == nil {
+			return fmt.Errorf("credential %s not found in CDP", rs.Primary.ID)
+		}
+
+		// return the value via passed in pointer
+		*credential = *c
+
+		return nil
+	}
+}
+
+func testAccCheckAwsCredentialValues(credential *models.Credential, rName string, description string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if *credential.CredentialName != rName {
+			return utils.CheckStringEquals("credential.CredentialName", rName, *credential.CredentialName)
+		}
+
+		if *credential.CloudPlatform != "AWS" {
+			return utils.CheckStringEquals("credential.CloudPlatform", "AWS", *credential.CloudPlatform)
+		}
+
+		if credential.Description != description {
+			return utils.CheckStringEquals("credential.Description", description, credential.Description)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAwsCredentialDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "cdp_environments_aws_credential" {
+			continue
+		}
+
+		cdpClient := cdpacctest.GetCdpClientForAccTest()
+
+		c, err := environments.FindCredentialByName(context.Background(), cdpClient, rs.Primary.ID)
+		if err != nil {
+			return nil
+		}
+
+		if c != nil {
+			return fmt.Errorf("credential %s not deleted in CDP", rs.Primary.ID)
+		}
+	}
+	return nil
+}

--- a/utils/string_utils.go
+++ b/utils/string_utils.go
@@ -1,0 +1,29 @@
+// Copyright 2023 Cloudera. All Rights Reserved.
+//
+// This file is licensed under the Apache License Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, either express or implied. Refer to the License for the specific
+// permissions and limitations governing your use of the file.
+
+package utils
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Concat concatenates input strings
+func Concat(strs ...string) string {
+	return strings.Join(strs, "")
+}
+
+// CheckStringEquals checks whether two strings are equal and returns nil if so, and an error otherwise.
+func CheckStringEquals(name string, expected string, actual string) error {
+	if expected != actual {
+		return fmt.Errorf("%s name does not match, expected %q, actual: %q", name, expected, actual)
+	}
+	return nil
+}

--- a/utils/string_utils_test.go
+++ b/utils/string_utils_test.go
@@ -1,0 +1,26 @@
+// Copyright 2023 Cloudera. All Rights Reserved.
+//
+// This file is licensed under the Apache License Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, either express or implied. Refer to the License for the specific
+// permissions and limitations governing your use of the file.
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/common"
+)
+
+func TestConcat(t *testing.T) {
+	common.AssertEquals(t, Concat(""), "")
+	common.AssertEquals(t, Concat("", "a"), "a")
+	common.AssertEquals(t, Concat("a", ""), "a")
+	common.AssertEquals(t, Concat("a", "b"), "ab")
+	common.AssertEquals(t, Concat("a", "b", "c"), "abc")
+	common.AssertEquals(t, Concat("a", " ", "c"), "a c")
+}


### PR DESCRIPTION
I've added our first TF acceptance test which creates and destroys an AWS credential. Terraform plugin framework has good support for writing these type of tests which are all structured very similarly. For all of the other data sources and resources, we can follow the same patterns established in this PR.

Mainly:
 - I added a new package called cdpacctest which contains common functionality for all acceptance tests in all other packages.
 - I added ID fields to data sources and resources whenever needed since the id field is required for acceptance tests.
- In resource_aws_credential.go, added plan modifiers for unknown fields since otherwise, TF will artifically try to replace the resource.
- Fixed a bug in the description field (Null value handling).
- Added retries to the CDP api call since we keep running into the eventual consistency issue between the test adding IAM policies and roles and the CDP side using them to verify cross account access.
- TestAccAwsCredential_basic is the main acceptance test for the AWS Credential. It runs with a test config which first declares the base AWS IAM cross account role and then adds a cdp resource for cdp_environments_aws_credential that points to this AWS role for cross account access. The AWS IAM resources are borrowed from the terraform-cdp-modules project, but I've simplified most of it. The test uses the data source "cdp_environments_aws_credential_prerequisites" for querying CDP for cdp account id and per-tenant external id.
- The test runs terraform apply / refresh / import / destroy in the backend and we use various "check" functions to check the state in the terraform state files as well as the state in the CDP control plane.

Running acceptance tests creates real infrastructure and costs real money and also takes non-trial amount of time. But this will be the process to automate most of the CDP provider testing for individual resources.

For running the tests, first we need a profile in CDP and a profile / credentials in AWS. Cloudera developers can use: `gimme-aws-creds" to get temp credentials to AWS. The CDP credentials can either be provided via CDP_ACCESS_KEY_ID and CDP_PRIVATE_KEY env variables, or can be put in the shared credentials file under a profile (use cdp config or edit ~/.cdp/credentials).

Running the tests:
```
CDP_PROFILE=<my-cdp-profile> AWS_PROFILE=<my-aws-profile>  make testacc  TESTARGS='-run=TestAccAwsCredential_basic'
```