### PR TITLE
cdp_environments_aws_environment overrides security_group_ids_for_knox with default_security_group_ids

### DIFF
--- a/resources/environments/resource_aws_environment.go
+++ b/resources/environments/resource_aws_environment.go
@@ -204,7 +204,7 @@ func toAwsEnvironmentResource(ctx context.Context, env *environmentsmodels.Envir
 		}
 		var sgIDsknox types.Set
 		if model.SecurityAccess != nil && !model.SecurityAccess.SecurityGroupIDsForKnox.IsUnknown() {
-			sgIDsknox = model.SecurityAccess.DefaultSecurityGroupIDs
+			sgIDsknox = model.SecurityAccess.SecurityGroupIDsForKnox
 		}
 		model.SecurityAccess = &SecurityAccess{
 			Cidr:                    types.StringValue(env.SecurityAccess.Cidr),


### PR DESCRIPTION
When applying `cdp_environments_aws_environment` with `security_access.default_security_group_ids` and `security_access.security_group_ids_for_knox` set, Terraform eventually terminates with an error, saying that there is a bug in the provider.

Snippet from tf file:
```
resource "cdp_environments_aws_environment" "cdp_env" {
 ...
  security_access = {
    default_security_group_ids  = ["sg-01234567890a", "sg-01234567890b", "sg-01234567890c"]
    security_group_ids_for_knox =  ["sg-01234567890a", "sg-01234567890b", "sg-01234567890d"]
  }
 ...
}
```

Error produced by Terraform:
```
│ Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to cdp_environments_aws_environment.cdp_env, provider "provider[\"registry.terraform.io/cloudera/cdp\"]" produced an unexpected new value: .security_access.security_group_ids_for_knox: planned set element cty.StringVal("sg-01234567890d") does not correlate with any element in actual.
│ 
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
```

A quick look into the Terraform state file showed, that the values for `security_group_id_for_knox` have been overwritten with `default_security_group_ids`.
```json
{
...
    "security_access": {
      "cidr": "",
      "default_security_group_id": "sg-01234567890a,sg-01234567890b,sg-01234567890c",
      "default_security_group_ids": [
        "sg-01234567890a",
        "sg-01234567890b",
        "sg-01234567890c"
      ],
      "security_group_id_for_knox": "sg-01234567890a,sg-01234567890b,sg-01234567890d",
      "security_group_ids_for_knox": [
        "sg-01234567890a",
        "sg-01234567890b",
        "sg-01234567890c"
      ]
    }
...
}
```

With the fix implemented in this PR, it works successfully. 

Terraform version: v1.9.1
CDP Terraform provider version: 0.6.1