### PR TITLE
PR #147: Machine User Role and Resource Role Assignment Fails

### DIFF
--- a/cdp-sdk-go/cdp/client.go
+++ b/cdp-sdk-go/cdp/client.go
@@ -34,7 +34,7 @@ type Client struct {
 }
 
 func NewClient(config *Config) (*Client, error) {
-	if err := config.loadConfig(); err != nil {
+	if err := config.LoadConfig(); err != nil {
 		return nil, err
 	}
 

--- a/cdp-sdk-go/cdp/config.go
+++ b/cdp-sdk-go/cdp/config.go
@@ -89,7 +89,7 @@ func NewConfig() *Config {
 	}
 }
 
-func (config *Config) loadConfig() error {
+func (config *Config) LoadConfig() error {
 	if config.BaseApiPath == "" {
 		config.BaseApiPath = defaultBaseApiPath
 	}

--- a/cdp-sdk-go/cdp/config_test.go
+++ b/cdp-sdk-go/cdp/config_test.go
@@ -90,7 +90,7 @@ func TestGetCredentialsNotFound(t *testing.T) {
 		Profile:         profile,
 		CredentialsFile: path,
 	}
-	err := emptyConfig.loadConfig()
+	err := emptyConfig.LoadConfig()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,7 +118,7 @@ func TestGetCdpCredentials(t *testing.T) {
 			AccessKeyId: "value-from-config",
 			PrivateKey:  "value-from-config"},
 	}
-	err := config.loadConfig()
+	err := config.LoadConfig()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -164,9 +164,9 @@ func TestLoadConfigFileNotFound(t *testing.T) {
 		ConfigFile: "testdata/non-existent-file",
 	}
 	// should silently ignore non existent files
-	err := config.loadConfig()
+	err := config.LoadConfig()
 	if err != nil {
-		t.Errorf("Unexpected error from loadConfig()")
+		t.Errorf("Unexpected error from LoadConfig()")
 	}
 }
 
@@ -176,7 +176,7 @@ func TestLoadConfigFile(t *testing.T) {
 	config := Config{
 		ConfigFile: "testdata/test-config",
 	}
-	err := config.loadConfig()
+	err := config.LoadConfig()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -193,7 +193,7 @@ func TestLoadConfigFileFromEnv(t *testing.T) {
 	config := Config{
 		ConfigFile: "testdata/test-config",
 	}
-	err := config.loadConfig()
+	err := config.LoadConfig()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -210,7 +210,7 @@ func TestGetCdpProfileCaseSensitivity(t *testing.T) {
 		ConfigFile: "testdata/test-config",
 		Profile:    "UPPER_CASE_PROFILE",
 	}
-	err := config.loadConfig()
+	err := config.LoadConfig()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -256,7 +256,7 @@ func TestGetCdpRegionFromConfigFile(t *testing.T) {
 		Profile:    "foo",
 		ConfigFile: "testdata/test-config",
 	}
-	err := config.loadConfig()
+	err := config.LoadConfig()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -281,7 +281,7 @@ func TestGetEndpointsWithProfile(t *testing.T) {
 		Profile:    "foo",
 		ConfigFile: "testdata/test-config",
 	}
-	err := config.loadConfig()
+	err := config.LoadConfig()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -307,7 +307,7 @@ func TestGetEndpointsWithRegionInProfile(t *testing.T) {
 		Profile:    "bar",
 		ConfigFile: "testdata/test-config",
 	}
-	err := config.loadConfig()
+	err := config.LoadConfig()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -333,7 +333,7 @@ func TestDefaultEndpoints(t *testing.T) {
 		ConfigFile: "testdata/test-config",
 		Profile:    "non-existing",
 	}
-	err := config.loadConfig()
+	err := config.LoadConfig()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/resources/iam/model_machine_user_resource_role_assignment.go
+++ b/resources/iam/model_machine_user_resource_role_assignment.go
@@ -15,6 +15,6 @@ import "github.com/hashicorp/terraform-plugin-framework/types"
 type machineUserResourceRoleAssignmentResourceModel struct {
 	Id              types.String `tfsdk:"id"`
 	MachineUser     types.String `tfsdk:"machine_user"`
-	ResourceCrn     types.String `tfsdk:"resource_role_crn"`
+	ResourceCrn     types.String `tfsdk:"resource_crn"`
 	ResourceRoleCrn types.String `tfsdk:"resource_role_crn"`
 }

--- a/resources/iam/resource_machine_user_resource_role_assignment_test.go
+++ b/resources/iam/resource_machine_user_resource_role_assignment_test.go
@@ -1,0 +1,178 @@
+// Copyright 2024 Cloudera. All Rights Reserved.
+//
+// This file is licensed under the Apache License Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, either express or implied. Refer to the License for the specific
+// permissions and limitations governing your use of the file.
+
+package iam_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/cloudera/terraform-provider-cdp/resources/iam"
+	"testing"
+
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/iam/client/operations"
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/iam/models"
+	"github.com/cloudera/terraform-provider-cdp/cdpacctest"
+	"github.com/cloudera/terraform-provider-cdp/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccIamMachineUserResourceRoleAssignment_basic(t *testing.T) {
+	cdpRegion, err := iam.GetCdpRegionFromConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	muName := acctest.RandomWithPrefix(cdpacctest.ResourcePrefix)
+	resourceRoleCrn := fmt.Sprintf("crn:altus:iam:%s:altus:resourceRole:IamGroupAdmin", cdpRegion)
+	resourceName := "cdp_iam_group.test"
+	resourceUnderTestName := "cdp_iam_machine_user_resource_role_assignment.test"
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { cdpacctest.PreCheck(t) },
+		ProtoV6ProviderFactories: cdpacctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: utils.Concat(
+					cdpacctest.TestAccCdpProviderConfig(),
+					testAccIamMachineUserResourceRoleAssignmentConfig(muName, resourceRoleCrn)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceUnderTestName, "machine_user", muName),
+					testAccCheckResourceAttrWith(resourceUnderTestName, "resource_crn", resourceAttrValue(resourceName, "crn")),
+					resource.TestCheckResourceAttr(resourceUnderTestName, "resource_role_crn", resourceRoleCrn),
+					testAccCheckResourceAttrWith(resourceUnderTestName, "id", statefValue(muName+"_%s_"+resourceRoleCrn, resourceAttrValue(resourceName, "crn"))),
+					testAccCheckIamMachineUserResourceRoleAssignmentExists(muName, resourceAttrValue(resourceName, "crn"), resourceRoleCrn),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func testAccIamMachineUserResourceRoleAssignmentConfig(muName string, resourceRoleCrn string) string {
+	return fmt.Sprintf(`
+resource "cdp_iam_machine_user" "test" {
+  name = %[1]q
+}
+
+resource "cdp_iam_group" "test" {
+	group_name = %[1]q
+}
+
+resource "cdp_iam_machine_user_resource_role_assignment" "test" {
+  machine_user = %[1]q
+  resource_crn = cdp_iam_group.test.crn
+  resource_role_crn = %[2]q
+  depends_on = [cdp_iam_machine_user.test]
+}
+`, muName, resourceRoleCrn)
+}
+
+// testAccCheckIamMachineUserRoleAssignmentExists queries the API and retrieves the matching IamMachineUserResourceRoleAssignment via the passed in pointer.
+func testAccCheckIamMachineUserResourceRoleAssignmentExists(muName string, resourceCrnFn func(s *terraform.State) (string, error), resourceRoleCrn string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		cdpClient := cdpacctest.GetCdpClientForAccTest()
+
+		params := operations.NewListMachineUserAssignedResourceRolesParamsWithContext(context.TODO())
+		params.WithInput(&models.ListMachineUserAssignedResourceRolesRequest{
+			MachineUserName: &muName,
+		})
+
+		responseOk, err := cdpClient.Iam.Operations.ListMachineUserAssignedResourceRoles(params)
+		if err != nil {
+			if d, ok := err.(*operations.ListMachineUserAssignedRolesDefault); ok && d.GetPayload() != nil && d.GetPayload().Code == "NOT_FOUND" {
+				return fmt.Errorf("machine user %s not found", muName)
+			}
+			return nil
+		}
+
+		resourceCrn, err := resourceCrnFn(s)
+		if err != nil {
+			return err
+		}
+
+		if len(responseOk.Payload.ResourceAssignments) != 1 ||
+			(*responseOk.Payload.ResourceAssignments[0].ResourceCrn != resourceCrn &&
+				*responseOk.Payload.ResourceAssignments[0].ResourceRoleCrn != resourceRoleCrn) {
+			return fmt.Errorf("machine user resource role assignment %s on resource %s not found", resourceRoleCrn, resourceCrn)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckResourceAttrWith(name, key string, valueFn func(s *terraform.State) (string, error)) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		expectedValue, err := valueFn(s)
+		if err != nil {
+			return err
+		}
+
+		is, err := modulePrimaryInstanceState(s.RootModule(), name)
+		if err != nil {
+			return err
+		}
+
+		actualValue, ok := is.Attributes[key]
+		if !ok {
+			return fmt.Errorf("%s: Attribute '%s' not found", name, key)
+		}
+		if actualValue != expectedValue {
+			return fmt.Errorf("%s: Attribute '%s' expected %#v, got %#v", name, key, expectedValue, actualValue)
+		}
+
+		return nil
+	}
+}
+
+func modulePrimaryInstanceState(ms *terraform.ModuleState, name string) (*terraform.InstanceState, error) {
+	rs, ok := ms.Resources[name]
+	if !ok {
+		return nil, fmt.Errorf("Not found: %s in %s", name, ms.Path)
+	}
+
+	is := rs.Primary
+	if is == nil {
+		return nil, fmt.Errorf("No primary instance: %s in %s", name, ms.Path)
+	}
+
+	return is, nil
+}
+
+func resourceAttrValue(name, key string) func(s *terraform.State) (string, error) {
+	return func(s *terraform.State) (string, error) {
+		is, err := modulePrimaryInstanceState(s.RootModule(), name)
+		if err != nil {
+			return "", err
+		}
+
+		value, ok := is.Attributes[key]
+		if !ok {
+			return "", fmt.Errorf("%s: Attribute '%s' not found", name, key)
+		}
+
+		return value, nil
+	}
+}
+
+func statefValue(format string, a ...func(s *terraform.State) (string, error)) func(s *terraform.State) (string, error) {
+	return func(s *terraform.State) (string, error) {
+		values := make([]any, len(a))
+		for i, fn := range a {
+			var err error
+			values[i], err = fn(s)
+			if err != nil {
+				return "", err
+			}
+		}
+		return fmt.Sprintf(format, values...), nil
+	}
+}

--- a/resources/iam/resource_machine_user_role_assignment_test.go
+++ b/resources/iam/resource_machine_user_role_assignment_test.go
@@ -1,0 +1,96 @@
+// Copyright 2024 Cloudera. All Rights Reserved.
+//
+// This file is licensed under the Apache License Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, either express or implied. Refer to the License for the specific
+// permissions and limitations governing your use of the file.
+
+package iam_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/cloudera/terraform-provider-cdp/resources/iam"
+	"testing"
+
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/iam/client/operations"
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/iam/models"
+	"github.com/cloudera/terraform-provider-cdp/cdpacctest"
+	"github.com/cloudera/terraform-provider-cdp/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccIamMachineUserRoleAssignment_basic(t *testing.T) {
+	cdpRegion, err := iam.GetCdpRegionFromConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	muName := acctest.RandomWithPrefix(cdpacctest.ResourcePrefix)
+	roleCrn := fmt.Sprintf("crn:altus:iam:%s:altus:role:IamViewer", cdpRegion)
+	resourceName := "cdp_iam_machine_user_role_assignment.test"
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { cdpacctest.PreCheck(t) },
+		ProtoV6ProviderFactories: cdpacctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: utils.Concat(
+					cdpacctest.TestAccCdpProviderConfig(),
+					testAccIamMachineUserRoleAssignmentConfig(muName, roleCrn)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "machine_user", muName),
+					resource.TestCheckResourceAttr(resourceName, "role", roleCrn),
+					resource.TestCheckResourceAttr(resourceName, "id", muName+"_"+roleCrn),
+					testAccCheckIamMachineUserRoleAssignmentExists(muName, roleCrn),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func testAccIamMachineUserRoleAssignmentConfig(muName string, roleName string) string {
+	return fmt.Sprintf(`
+resource "cdp_iam_machine_user" "test" {
+  name = %[1]q
+}
+
+resource "cdp_iam_machine_user_role_assignment" "test" {
+  machine_user = %[1]q
+  role = %[2]q
+  depends_on = [cdp_iam_machine_user.test]
+}
+`, muName, roleName)
+}
+
+// testAccCheckIamMachineUserRoleAssignmentExists queries the API and retrieves the matching IamMachineUserRoleAssignment via the passed in pointer.
+func testAccCheckIamMachineUserRoleAssignmentExists(muName, roleName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		cdpClient := cdpacctest.GetCdpClientForAccTest()
+
+		params := operations.NewListMachineUserAssignedRolesParamsWithContext(context.TODO())
+		params.WithInput(&models.ListMachineUserAssignedRolesRequest{
+			MachineUserName: &muName,
+		})
+
+		responseOk, err := cdpClient.Iam.Operations.ListMachineUserAssignedRoles(params)
+		if err != nil {
+			if d, ok := err.(*operations.ListMachineUserAssignedRolesDefault); ok && d.GetPayload() != nil && d.GetPayload().Code == "NOT_FOUND" {
+				return fmt.Errorf("machine user %s not found", muName)
+			}
+			return nil
+		}
+
+		if len(responseOk.Payload.RoleCrns) != 1 || responseOk.Payload.RoleCrns[0] != roleName {
+			return fmt.Errorf("machine user role assignment %s not found", roleName)
+		}
+
+		return nil
+	}
+}

--- a/resources/iam/test_common_utils.go
+++ b/resources/iam/test_common_utils.go
@@ -11,6 +11,7 @@
 package iam
 
 import (
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/cdp"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"testing"
 )
@@ -35,4 +36,12 @@ func PerformSchemaValidationForResource(t *testing.T, test SchemaTestCaseStructu
 			t.Errorf("The '%s' filed's >computed< property should be: %t", test.field, test.computed)
 		}
 	})
+}
+
+func GetCdpRegionFromConfig() (string, error) {
+	config := cdp.NewConfig()
+	if err := config.LoadConfig(); err != nil {
+		return "", err
+	}
+	return config.GetCdpRegion()
 }


### PR DESCRIPTION
We want to assign a `role` to a `machine user` via the Terraform resource `cdp_iam_machine_user_role_assignment`:

```bash
resource "cdp_iam_machine_user" "provisioning" {
  name = "dev-provisioning"
}

resource "cdp_iam_machine_user_role_assignment" "provisioning_environment_admin" {
  machine_user = cdp_iam_machine_user.provisioning.name
  role                   = "crn:altus:iam:eu-1:altus:role:EnvironmentAdmin"

  depends_on = [ cdp_iam_machine_user.provisioning ]
}
````

When applying the changes, Terraform fails with a nil pointer dereference error:

```
cdp_iam_machine_user_role_assignment.provisioning_environment_admin: Creating...
╷
│ Error: Request cancelled
│
│ The plugin6.(*GRPCProvider).ApplyResourceChange request was cancelled.
╵
 
Stack trace from the terraform-provider-cdp_v0.6.2 plugin:
 
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0xea1cc2]
 
goroutine 83 [running]:
github.com/cloudera/terraform-provider-cdp/resources/iam.(*machineUserRoleAssignmentResource).Create(0xc000118740, {0x16eff28, 0xc0003507e0}, {{{{0x16f6478, 0xc000350f00}, {0x129c4e0, 0xc000350e10}}, {0x16f84e8, 0xc0004a6be0}}, {{{0x16f6478, ...}, ...}, ...}, ...}, ...)
        github.com/cloudera/terraform-provider-cdp/resources/iam/resource_machine_user_role_assignment.go:59 +0x362
github.com/hashicorp/terraform-plugin-framework/internal/fwserver.(*Server).CreateResource(0xc00041c9c0, {0x16eff28, 0xc0003507e0}, 0xc0005315e0, 0xc0005315b8)
        github.com/hashicorp/terraform-plugin-framework@v1.7.0/internal/fwserver/server_createresource.go:101 +0x578
github.com/hashicorp/terraform-plugin-framework/internal/fwserver.(*Server).ApplyResourceChange(0xc00041c9c0, {0x16eff28, 0xc0003507e0}, 0xc0002a3360, 0xc0005316d0)
        github.com/hashicorp/terraform-plugin-framework@v1.7.0/internal/fwserver/server_applyresourcechange.go:57 +0x4aa
github.com/hashicorp/terraform-plugin-framework/internal/proto6server.(*Server).ApplyResourceChange(0xc00041c9c0, {0x16eff28?, 0xc0003506f0?}, 0xc0002a32c0)
        github.com/hashicorp/terraform-plugin-framework@v1.7.0/internal/proto6server/server_applyresourcechange.go:55 +0x38e
github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server.(*server).ApplyResourceChange(0xc00043fd60, {0x16eff28?, 0xc000497ce0?}, 0xc000411b90)
        github.com/hashicorp/terraform-plugin-go@v0.22.1/tfprotov6/tf6server/server.go:846 +0x3d0
github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/tfplugin6._Provider_ApplyResourceChange_Handler({0x14c3700, 0xc00043fd60}, {0x16eff28, 0xc000497ce0}, 0xc000433000, 0x0)
        github.com/hashicorp/terraform-plugin-go@v0.22.1/tfprotov6/internal/tfplugin6/tfplugin6_grpc.pb.go:518 +0x1a6
google.golang.org/grpc.(*Server).processUnaryRPC(0xc000428000, {0x16eff28, 0xc000497c50}, {0x16f6ce0, 0xc0001741a0}, 0xc000332d80, 0xc00050c960, 0x2311498, 0x0)
        google.golang.org/grpc@v1.62.1/server.go:1386 +0xdf8
google.golang.org/grpc.(*Server).handleStream(0xc000428000, {0x16f6ce0, 0xc0001741a0}, 0xc000332d80)
        google.golang.org/grpc@v1.62.1/server.go:1797 +0xe87
google.golang.org/grpc.(*Server).serveStreams.func2.1()
        google.golang.org/grpc@v1.62.1/server.go:1027 +0x8b
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 27
        google.golang.org/grpc@v1.62.1/server.go:1038 +0x125
 
Error: The terraform-provider-cdp_v0.6.2 plugin crashed!
 
This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.
```

The reason for this is, that for this resource, the CDP client has not been initialized. Basically the following code was missing:

```go
r.client = utils.GetCdpClientForResource(req, resp)
```

After fixing this, applying the change still failed:

```
cdp_iam_machine_user_role_assignment.provisioning_environment_admin: Creating...
╷
│ Error: Provider returned invalid result object after apply
│
│ After the apply operation, the provider still indicated an unknown value for cdp_iam_machine_user_role_assignment.provisioning_environment_admin.id. All values must be known after apply, so this is always a bug in the provider and should be reported in the provider's own repository. Terraform will still save the other known object values in the state.
╵
```

It showed that the reason is, that the `cdp_iam_machine_user_role_assignment` does not assign an id to the response.
After assigning an id with the following code it worked:
```go
data.Id = types.StringValue(data.MachineUser.ValueString() + "_" + data.Role.ValueString())
```

The resource  `cdp_iam_machine_user_resource_role_assignment` has the exact same problem, so I fixed both with this PR. 

Terraform version: v1.9.3
CDP Provider version: v0.6.2