### PR TITLE
CDPCP-12598 Skip CDW Hive test if env var is not set

### DIFF
--- a/resources/dw/resource_hive_vw_acc_test.go
+++ b/resources/dw/resource_hive_vw_acc_test.go
@@ -33,12 +33,12 @@ type hiveTestParameters struct {
 }
 
 func HivePreCheck(t *testing.T) {
-	errMsg := "AWS Terraform acceptance testing requires environment variable %s to be set"
+	errMsg := "AWS CDW Hive Terraform acceptance testing requires environment variable %s to be set"
 	if _, ok := os.LookupEnv("CDW_CLUSTER_ID"); !ok {
-		t.Fatalf(errMsg, "CDW_CLUSTER_ID")
+		t.Skipf(errMsg, "CDW_CLUSTER_ID")
 	}
 	if _, ok := os.LookupEnv("CDW_DATABASE_CATALOG_ID"); !ok {
-		t.Fatalf(errMsg, "CDW_DATABASE_CATALOG_ID")
+		t.Skipf(errMsg, "CDW_DATABASE_CATALOG_ID")
 	}
 }
 


### PR DESCRIPTION
The acceptance test will be skipped until the dependent objects - CDW cluster and database catalog - are properly allocated and awaited by their respective tests.