### PR TITLE
DWX-18764 Move polling utilities to utils

### DIFF
--- a/resources/dw/virtualwarehouse/hive/model_hive_vw.go
+++ b/resources/dw/virtualwarehouse/hive/model_hive_vw.go
@@ -11,8 +11,6 @@
 package hive
 
 import (
-	"time"
-
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/cloudera/terraform-provider-cdp/utils"
@@ -28,17 +26,6 @@ type resourceModel struct {
 	PollingOptions    *utils.PollingOptions `tfsdk:"polling_options"`
 }
 
-// TODO these are the same everywhere, abstract this
-func (p *resourceModel) getPollingTimeout() time.Duration {
-	if p.PollingOptions != nil {
-		return time.Duration(p.PollingOptions.PollingTimeout.ValueInt64()) * time.Minute
-	}
-	return 40 * time.Minute
-}
-
-func (p *resourceModel) getCallFailureThreshold() int {
-	if p.PollingOptions != nil {
-		return int(p.PollingOptions.CallFailureThreshold.ValueInt64())
-	}
-	return 3
+func (p *resourceModel) GetPollingOptions() *utils.PollingOptions {
+	return p.PollingOptions
 }

--- a/resources/dw/virtualwarehouse/hive/resource_hive_vw_acc_test.go
+++ b/resources/dw/virtualwarehouse/hive/resource_hive_vw_acc_test.go
@@ -8,6 +8,8 @@
 // OF ANY KIND, either express or implied. Refer to the License for the specific
 // permissions and limitations governing your use of the file.
 
+//go:build hive
+
 package hive_test
 
 import (

--- a/resources/dw/virtualwarehouse/hive/resource_hive_vw_test.go
+++ b/resources/dw/virtualwarehouse/hive/resource_hive_vw_test.go
@@ -13,14 +13,14 @@ package hive
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"testing"
 
 	"github.com/go-openapi/runtime"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"


### PR DESCRIPTION
The timeout and threshold calculation is duplicated in every dw module, it is moved to utils to reduce duplication.