### PR TITLE
Add linter to standardize golang import order

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,34 @@
+---
+run:
+  tests: true
+
+linters:
+  disable-all: true
+  enable:
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - gci
+
+linters-settings:
+  gci:
+    sections:
+      - standard # Standard section: captures all standard packages.
+      - default # Default section: contains all imports that could not be matched to another section type.
+      - prefix(github.com/cloudera/terraform-provider-cdp) # Custom section: groups all imports with the specified Prefix.
+      - blank # Blank section: contains all blank imports. This section is not present unless explicitly enabled.
+      - dot # Dot section: contains all dot imports. This section is not present unless explicitly enabled.
+    # Skip generated files.
+    # Default: true
+    skip-generated: true
+
+output:
+  format: colored-line-number
+  print-issued-lines: false
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,10 @@ build: generate fmt vet
 lint:
 	golangci-lint run
 
+# See https://golangci-lint.run/
+fix:
+	golangci-lint run --fix
+
 install: main
 	go install .
 

--- a/cdp-sdk-go/cdp/retryable_transport_test.go
+++ b/cdp-sdk-go/cdp/retryable_transport_test.go
@@ -13,11 +13,12 @@ package cdp
 import (
 	"bytes"
 	"fmt"
-	"github.com/jarcoal/httpmock"
 	"io"
 	"net/http"
 	"os"
 	"testing"
+
+	"github.com/jarcoal/httpmock"
 )
 
 const (

--- a/cdp-sdk-go/cdp/transport_test.go
+++ b/cdp-sdk-go/cdp/transport_test.go
@@ -12,12 +12,13 @@ package cdp
 
 import (
 	"context"
-	"github.com/go-openapi/errors"
-	"github.com/go-openapi/runtime"
-	"github.com/go-openapi/strfmt"
 	"net/http"
 	"regexp"
 	"testing"
+
+	"github.com/go-openapi/errors"
+	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/strfmt"
 )
 
 var (

--- a/cdpacctest/acctest.go
+++ b/cdpacctest/acctest.go
@@ -18,12 +18,13 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/cdp"
-	"github.com/cloudera/terraform-provider-cdp/provider"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/pkg/errors"
+
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/cdp"
+	"github.com/cloudera/terraform-provider-cdp/provider"
 )
 
 const (

--- a/main.go
+++ b/main.go
@@ -15,8 +15,9 @@ import (
 	"flag"
 	"log"
 
-	"github.com/cloudera/terraform-provider-cdp/provider"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+
+	"github.com/cloudera/terraform-provider-cdp/provider"
 )
 
 var (

--- a/resources/datahub/constants_test.go
+++ b/resources/datahub/constants_test.go
@@ -10,8 +10,10 @@
 
 package datahub
 
-import "reflect"
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestFailedStatusKeywords(t *testing.T) {
 	expected := [2]string{"FAILED", "DELETED"}

--- a/resources/datahub/converter_test.go
+++ b/resources/datahub/converter_test.go
@@ -14,9 +14,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/cloudera/terraform-provider-cdp/utils/test"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/cloudera/terraform-provider-cdp/utils/test"
 )
 
 func TestFromModelToRequestBasicFields(t *testing.T) {

--- a/resources/datahub/model_datahub_test.go
+++ b/resources/datahub/model_datahub_test.go
@@ -11,8 +11,9 @@
 package datahub
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func TestForceDeleteRequestedForAws(t *testing.T) {

--- a/resources/datahub/model_gcp_datahub_test.go
+++ b/resources/datahub/model_gcp_datahub_test.go
@@ -11,8 +11,9 @@
 package datahub
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func TestForceDeleteRequestedForGcp(t *testing.T) {

--- a/resources/datahub/polling.go
+++ b/resources/datahub/polling.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 

--- a/resources/datahub/schema_aws_datahub_test.go
+++ b/resources/datahub/schema_aws_datahub_test.go
@@ -12,9 +12,10 @@ package datahub
 
 import (
 	"context"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"testing"
 )
 
 func TestAwsSchemaContainsCommonElements(t *testing.T) {

--- a/resources/datahub/schema_azure_datahub_test.go
+++ b/resources/datahub/schema_azure_datahub_test.go
@@ -12,9 +12,10 @@ package datahub
 
 import (
 	"context"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"testing"
 )
 
 func TestAzureSchemaContainsCommonElements(t *testing.T) {

--- a/resources/datahub/schema_gcp_datahub_test.go
+++ b/resources/datahub/schema_gcp_datahub_test.go
@@ -12,7 +12,6 @@ package datahub
 
 import (
 	"context"
-
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"

--- a/resources/datalake/converter_gcp.go
+++ b/resources/datalake/converter_gcp.go
@@ -14,9 +14,8 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	datalakemodels "github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/datalake/models"
 	"github.com/cloudera/terraform-provider-cdp/utils"

--- a/resources/datalake/converter_gcp_test.go
+++ b/resources/datalake/converter_gcp_test.go
@@ -11,8 +11,9 @@
 package datalake
 
 import (
-	"github.com/go-openapi/strfmt"
 	"testing"
+
+	"github.com/go-openapi/strfmt"
 
 	datalakemodels "github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/datalake/models"
 )

--- a/resources/datalake/resource_aws_datalake_test.go
+++ b/resources/datalake/resource_aws_datalake_test.go
@@ -17,14 +17,15 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
 	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/cdp"
 	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/datalake/client/operations"
 	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/datalake/models"
 	"github.com/cloudera/terraform-provider-cdp/cdpacctest"
 	"github.com/cloudera/terraform-provider-cdp/utils"
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const (

--- a/resources/datalake/resource_azure_datalake_test.go
+++ b/resources/datalake/resource_azure_datalake_test.go
@@ -14,9 +14,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/cloudera/terraform-provider-cdp/utils/test"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/cloudera/terraform-provider-cdp/utils/test"
 )
 
 func TestFromModelToAzureRequestBasicFields(t *testing.T) {

--- a/resources/de/resource_data_engineering_service.go
+++ b/resources/de/resource_data_engineering_service.go
@@ -14,16 +14,16 @@ import (
 	"context"
 	"errors"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
 	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/cdp"
 	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/de/client/operations"
 	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/de/models"
 	"github.com/cloudera/terraform-provider-cdp/utils"
-	"github.com/hashicorp/terraform-plugin-framework/types"
-
-	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var _ resource.Resource = (*serviceResource)(nil)

--- a/resources/de/schema_data_engineering_service.go
+++ b/resources/de/schema_data_engineering_service.go
@@ -11,9 +11,8 @@
 package de
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/types"
-
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 var serviceSchema = schema.Schema{

--- a/resources/dw/cluster/aws/model_cluster_test.go
+++ b/resources/dw/cluster/aws/model_cluster_test.go
@@ -12,12 +12,14 @@ package aws
 
 import (
 	"context"
-	models2 "github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/dw/models"
+	"testing"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/stretchr/testify/suite"
-	"testing"
-	"time"
+
+	models2 "github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/dw/models"
 )
 
 type DwClusterModelTestSuite struct {

--- a/resources/dw/cluster/aws/resource_cluster_acc_test.go
+++ b/resources/dw/cluster/aws/resource_cluster_acc_test.go
@@ -13,16 +13,18 @@ package aws_test
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
 	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/dw/client/operations"
 	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/dw/models"
 	"github.com/cloudera/terraform-provider-cdp/cdpacctest"
 	"github.com/cloudera/terraform-provider-cdp/utils"
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"os"
-	"strings"
-	"testing"
 )
 
 const (

--- a/resources/dw/databasecatalog/model_catalog_test.go
+++ b/resources/dw/databasecatalog/model_catalog_test.go
@@ -12,11 +12,12 @@ package databasecatalog
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/stretchr/testify/suite"
-	"testing"
-	"time"
 )
 
 type DwDatabaseCatalogModelTestSuite struct {

--- a/resources/environments/converter_freeipa.go
+++ b/resources/environments/converter_freeipa.go
@@ -13,11 +13,12 @@ package environments
 import (
 	"context"
 
-	environmentsmodels "github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/models"
-	"github.com/cloudera/terraform-provider-cdp/utils"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+
+	environmentsmodels "github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/models"
+	"github.com/cloudera/terraform-provider-cdp/utils"
 )
 
 func FreeIpaResponseToModel(ipaResp *environmentsmodels.FreeipaDetails, model *types.Object, ctx context.Context) *diag.Diagnostics {

--- a/resources/environments/data_source_keytab.go
+++ b/resources/environments/data_source_keytab.go
@@ -12,6 +12,7 @@ package environments
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"

--- a/resources/environments/data_source_keytab_test.go
+++ b/resources/environments/data_source_keytab_test.go
@@ -13,14 +13,15 @@ package environments
 import (
 	"context"
 	"errors"
+	"strings"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"strings"
-	"testing"
 
 	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/cdp"
 	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/client/operations"

--- a/resources/environments/polling.go
+++ b/resources/environments/polling.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 
 	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/client"

--- a/resources/environments/resource_aws_credential_test.go
+++ b/resources/environments/resource_aws_credential_test.go
@@ -16,13 +16,14 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
 	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/models"
 	"github.com/cloudera/terraform-provider-cdp/cdpacctest"
 	"github.com/cloudera/terraform-provider-cdp/resources/environments"
 	"github.com/cloudera/terraform-provider-cdp/utils"
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccAwsCredential_basic(t *testing.T) {

--- a/resources/environments/resource_azure_credential.go
+++ b/resources/environments/resource_azure_credential.go
@@ -13,15 +13,16 @@ package environments
 import (
 	"context"
 
-	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/cdp"
-	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/client/operations"
-	environmentsmodels "github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/models"
-	"github.com/cloudera/terraform-provider-cdp/utils"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/cdp"
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/client/operations"
+	environmentsmodels "github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/models"
+	"github.com/cloudera/terraform-provider-cdp/utils"
 )
 
 var (

--- a/resources/environments/resource_azure_image_terms.go
+++ b/resources/environments/resource_azure_image_terms.go
@@ -13,13 +13,14 @@ package environments
 import (
 	"context"
 
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/cdp"
 	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/client/operations"
 	environmentsmodels "github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/models"
 	"github.com/cloudera/terraform-provider-cdp/utils"
-	"github.com/google/uuid"
-	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 var (

--- a/resources/environments/resource_azure_image_terms_test.go
+++ b/resources/environments/resource_azure_image_terms_test.go
@@ -15,15 +15,16 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/cdp"
-	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/client/operations"
-	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/models"
-	mocks "github.com/cloudera/terraform-provider-cdp/mocks/github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/client/operations"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/cdp"
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/client/operations"
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/models"
+	mocks "github.com/cloudera/terraform-provider-cdp/mocks/github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/client/operations"
 )
 
 func createRawAzureImageTermsResource(accepted bool) tftypes.Value {

--- a/resources/environments/resource_gcp_credential.go
+++ b/resources/environments/resource_gcp_credential.go
@@ -13,10 +13,10 @@ package environments
 import (
 	"context"
 	"encoding/base64"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/cdp"
 	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/client/operations"

--- a/resources/environments/resource_id_broker_mappings.go
+++ b/resources/environments/resource_id_broker_mappings.go
@@ -13,11 +13,6 @@ package environments
 import (
 	"context"
 
-	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/cdp"
-	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/client"
-	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/client/operations"
-	environmentsmodels "github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/models"
-	"github.com/cloudera/terraform-provider-cdp/utils"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -28,6 +23,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/cdp"
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/client"
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/client/operations"
+	environmentsmodels "github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/models"
+	"github.com/cloudera/terraform-provider-cdp/utils"
 )
 
 var (

--- a/resources/environments/resource_id_broker_mappings_test.go
+++ b/resources/environments/resource_id_broker_mappings_test.go
@@ -15,17 +15,18 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/cdp"
-	environmentsclient "github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/client"
-	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/client/operations"
-	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/models"
-	mocks "github.com/cloudera/terraform-provider-cdp/mocks/github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/client/operations"
 	"github.com/go-openapi/runtime"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/cdp"
+	environmentsclient "github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/client"
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/client/operations"
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/models"
+	mocks "github.com/cloudera/terraform-provider-cdp/mocks/github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/client/operations"
 )
 
 type MockOperations struct {

--- a/resources/environments/resource_user_sync.go
+++ b/resources/environments/resource_user_sync.go
@@ -15,11 +15,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/cdp"
-	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/client"
-	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/client/operations"
-	environmentsmodels "github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/models"
-	"github.com/cloudera/terraform-provider-cdp/utils"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -32,6 +27,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/cdp"
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/client"
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/client/operations"
+	environmentsmodels "github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/models"
+	"github.com/cloudera/terraform-provider-cdp/utils"
 )
 
 var (

--- a/resources/environments/schema_aws_credential_prerequisites.go
+++ b/resources/environments/schema_aws_credential_prerequisites.go
@@ -12,6 +12,7 @@ package environments
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"

--- a/resources/environments/schema_aws_environment.go
+++ b/resources/environments/schema_aws_environment.go
@@ -13,11 +13,10 @@ package environments
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
-
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"

--- a/resources/environments/schema_azure_environment.go
+++ b/resources/environments/schema_azure_environment.go
@@ -13,11 +13,10 @@ package environments
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
-
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"

--- a/resources/environments/schema_azure_environment_test.go
+++ b/resources/environments/schema_azure_environment_test.go
@@ -11,8 +11,9 @@
 package environments
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 )
 
 var schemaElements = []SchemaTestCaseStructure{

--- a/resources/environments/utils.go
+++ b/resources/environments/utils.go
@@ -12,6 +12,7 @@ package environments
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 

--- a/resources/environments/utils_test.go
+++ b/resources/environments/utils_test.go
@@ -11,10 +11,11 @@
 package environments
 
 import (
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"golang.org/x/net/context"
-	"testing"
 )
 
 func TestConvertTagsWhenInputIsNil(t *testing.T) {

--- a/resources/iam/converter.go
+++ b/resources/iam/converter.go
@@ -13,9 +13,10 @@ package iam
 import (
 	"context"
 
-	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/iam/models"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/iam/models"
 )
 
 func muRespToModel(ctx context.Context, mu *models.MachineUser, data *machineUserResourceModel) {

--- a/resources/iam/data_source_group.go
+++ b/resources/iam/data_source_group.go
@@ -12,10 +12,12 @@ package iam
 
 import (
 	"context"
-	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/cdp"
-	"github.com/cloudera/terraform-provider-cdp/utils"
+
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/cdp"
+	"github.com/cloudera/terraform-provider-cdp/utils"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/resources/iam/resource_group.go
+++ b/resources/iam/resource_group.go
@@ -12,11 +12,7 @@ package iam
 
 import (
 	"context"
-	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/cdp"
-	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/iam/client"
-	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/iam/client/operations"
-	iammodels "github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/iam/models"
-	"github.com/cloudera/terraform-provider-cdp/utils"
+
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -25,6 +21,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/cdp"
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/iam/client"
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/iam/client/operations"
+	iammodels "github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/iam/models"
+	"github.com/cloudera/terraform-provider-cdp/utils"
 )
 
 var (

--- a/resources/iam/resource_machine_user.go
+++ b/resources/iam/resource_machine_user.go
@@ -12,6 +12,7 @@ package iam
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"

--- a/resources/iam/resource_machine_user_group_assignment.go
+++ b/resources/iam/resource_machine_user_group_assignment.go
@@ -12,6 +12,7 @@ package iam
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"

--- a/resources/iam/resource_machine_user_resource_role_assignment.go
+++ b/resources/iam/resource_machine_user_resource_role_assignment.go
@@ -12,11 +12,10 @@ package iam
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-framework/types"
-
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/cdp"
 	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/iam/client/operations"

--- a/resources/iam/resource_machine_user_resource_role_assignment_test.go
+++ b/resources/iam/resource_machine_user_resource_role_assignment_test.go
@@ -13,16 +13,17 @@ package iam_test
 import (
 	"context"
 	"fmt"
-	"github.com/cloudera/terraform-provider-cdp/resources/iam"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/iam/client/operations"
 	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/iam/models"
 	"github.com/cloudera/terraform-provider-cdp/cdpacctest"
+	"github.com/cloudera/terraform-provider-cdp/resources/iam"
 	"github.com/cloudera/terraform-provider-cdp/utils"
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccIamMachineUserResourceRoleAssignment_basic(t *testing.T) {

--- a/resources/iam/resource_machine_user_role_assignment.go
+++ b/resources/iam/resource_machine_user_role_assignment.go
@@ -12,11 +12,10 @@ package iam
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-framework/types"
-
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/cdp"
 	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/iam/client/operations"

--- a/resources/iam/resource_machine_user_role_assignment_test.go
+++ b/resources/iam/resource_machine_user_role_assignment_test.go
@@ -13,16 +13,17 @@ package iam_test
 import (
 	"context"
 	"fmt"
-	"github.com/cloudera/terraform-provider-cdp/resources/iam"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/iam/client/operations"
 	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/iam/models"
 	"github.com/cloudera/terraform-provider-cdp/cdpacctest"
+	"github.com/cloudera/terraform-provider-cdp/resources/iam"
 	"github.com/cloudera/terraform-provider-cdp/utils"
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccIamMachineUserRoleAssignment_basic(t *testing.T) {

--- a/resources/iam/test_common_utils.go
+++ b/resources/iam/test_common_utils.go
@@ -11,8 +11,9 @@
 package iam
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
 	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/cdp"
 )

--- a/resources/ml/resource_workspace.go
+++ b/resources/ml/resource_workspace.go
@@ -14,15 +14,16 @@ import (
 	"context"
 	"errors"
 
-	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/cdp"
-	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/ml/client/operations"
-	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/ml/models"
-	"github.com/cloudera/terraform-provider-cdp/utils"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/cdp"
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/ml/client/operations"
+	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/ml/models"
+	"github.com/cloudera/terraform-provider-cdp/utils"
 )
 
 var _ resource.Resource = (*workspaceResource)(nil)

--- a/resources/ml/schema_workspace.go
+++ b/resources/ml/schema_workspace.go
@@ -11,9 +11,8 @@
 package ml
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/types"
-
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 var workspaceSchema = schema.Schema{

--- a/resources/opdb/constants_test.go
+++ b/resources/opdb/constants_test.go
@@ -10,8 +10,10 @@
 
 package opdb
 
-import "reflect"
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestFailedStatusKeywords(t *testing.T) {
 	expected := [5]string{"FAILED", "DELETE_FAILED", "MISSING", "CREATE_FAILED", "DELETED"}

--- a/resources/opdb/converter.go
+++ b/resources/opdb/converter.go
@@ -13,11 +13,12 @@ package opdb
 import (
 	"context"
 	"fmt"
-	"github.com/cloudera/terraform-provider-cdp/utils"
+
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	opdbmodels "github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/opdb/models"
+	"github.com/cloudera/terraform-provider-cdp/utils"
 )
 
 func fromModelToDatabaseRequest(model databaseResourceModel, ctx context.Context) *opdbmodels.CreateDatabaseRequest {

--- a/resources/opdb/converter_test.go
+++ b/resources/opdb/converter_test.go
@@ -14,9 +14,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/cloudera/terraform-provider-cdp/utils/test"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/cloudera/terraform-provider-cdp/utils/test"
 )
 
 func TestFromSimplestModelToDatabaseRequestBasicFields(t *testing.T) {

--- a/resources/opdb/polling.go
+++ b/resources/opdb/polling.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 

--- a/resources/opdb/resource_database.go
+++ b/resources/opdb/resource_database.go
@@ -13,6 +13,7 @@ package opdb
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"

--- a/resources/opdb/schema_database.go
+++ b/resources/opdb/schema_database.go
@@ -12,20 +12,18 @@ package opdb
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-
-	"github.com/hashicorp/terraform-plugin-framework/types"
-
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
-
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/cloudera/terraform-provider-cdp/utils"
 )

--- a/resources/opdb/schema_database_test.go
+++ b/resources/opdb/schema_database_test.go
@@ -12,9 +12,10 @@ package opdb
 
 import (
 	"context"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"testing"
 )
 
 func TestSchemaContainsCommonElements(t *testing.T) {

--- a/resources/opdb/utils.go
+++ b/resources/opdb/utils.go
@@ -13,9 +13,10 @@ package opdb
 import (
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/opdb/client/operations"
 	"github.com/cloudera/terraform-provider-cdp/utils"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func checkIfDatabaseCreationFailed(resp *operations.DescribeDatabaseOK) (interface{}, string, error) {

--- a/utils/log.go
+++ b/utils/log.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	environmentsmodels "github.com/cloudera/terraform-provider-cdp/cdp-sdk-go/gen/environments/models"

--- a/utils/schema_utils_test.go
+++ b/utils/schema_utils_test.go
@@ -11,8 +11,9 @@
 package utils
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 )
 
 func TestWithNoErrorAndAction(t *testing.T) {


### PR DESCRIPTION
The gci linter is added to the default linter list. The make fix command if run manually can fix the import problems in the project.