### PR TITLE
Improvement on make install-terraformrc goal

### DIFF
--- a/.terraformrc
+++ b/.terraformrc
@@ -1,7 +1,7 @@
 provider_installation {
 
   dev_overrides {
-      "cloudera/cdp" = "/Users/_USERNAME_/go/bin"
+      "cloudera/cdp" = "__GOHOME__/bin"
   }
 
   # For all other providers, install them directly from their origin provider

--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,15 @@
 
 GO_FLAGS:=""
 TESTARGS:=""
+GOPATH ?= $(shell go env GOPATH)
 
 all: check-go test main
 
 check-go:
-ifndef GOPATH
+ifeq ($(GOPATH),)
 	$(error GOPATH not defined, please define GOPATH. Run "go help gopath" to learn more about GOPATH)
+else
+	@echo "The GOPATH is OK: $(GOPATH)"
 endif
 
 # Run tests
@@ -49,8 +52,8 @@ install: main
 	go install .
 
 # for local development
-install-terraformrc:
-	cp -iv .terraformrc ~/.terraformrc && sed -i -e 's/_USERNAME_/$(USER)/g' ~/.terraformrc
+install-terraformrc: check-go
+	cp -iv .terraformrc ~/.terraformrc && sed -i -e 's%__GOHOME__%${GOPATH}%g' ~/.terraformrc
 
 # Make a release
 release: test testacc docs


### PR DESCRIPTION
Newer go installations don't require setting the GOPATH explicitly.
To make managing the GOHOME more flexible the `install-terraformrc` and `check-go` targets have been improved.