### PR TITLE
CDPCP-13607 Add go version 1.22 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: ['1.21']
+        go-version: ['1.21', '1.22']
 
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
@@ -70,7 +70,7 @@ jobs:
           - macos-latest
           - windows-latest
           - ubuntu-latest
-        go-version: ['1.21']
+        go-version: ['1.21', '1.22']
 
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4


### PR DESCRIPTION
The toolchain was upgraded to 1.22, the tests should be running on this version as well.