### PR TITLE
CDPCP-13540 DW New parameter: enable_private_eks

### DIFF
--- a/docs/resources/dw_aws_cluster.md
+++ b/docs/resources/dw_aws_cluster.md
@@ -41,6 +41,7 @@ resource "cdp_dw_aws_cluster" "example" {
     whitelist_workload_access_ip_cidrs    = ["0.0.0.0/0"]
     use_private_load_balancer             = true
     use_public_worker_node                = false
+    enable_private_eks                    = true
   }
   instance_settings = {
     custom_ami_id             = ""
@@ -101,6 +102,7 @@ Required:
 
 Optional:
 
+- `enable_private_eks` (Boolean) Enable private EKS API endpoint.
 - `whitelist_k8s_cluster_access_ip_cidrs` (List of String) The list of IP CIDRs to allow access for kubernetes cluster API endpoint.
 - `whitelist_workload_access_ip_cidrs` (List of String) The list of IP CIDRs to allow access for workload endpoints.
 

--- a/examples/resources/cdp_dw_aws_cluster/resource.tf
+++ b/examples/resources/cdp_dw_aws_cluster/resource.tf
@@ -27,6 +27,7 @@ resource "cdp_dw_aws_cluster" "example" {
     whitelist_workload_access_ip_cidrs    = ["0.0.0.0/0"]
     use_private_load_balancer             = true
     use_public_worker_node                = false
+    enable_private_eks                    = true
   }
   instance_settings = {
     custom_ami_id             = ""

--- a/resources/dw/cluster/aws/model_cluster.go
+++ b/resources/dw/cluster/aws/model_cluster.go
@@ -27,6 +27,7 @@ type networkResourceModel struct {
 	WhitelistWorkloadAccessIPCIDRs   types.List `tfsdk:"whitelist_workload_access_ip_cidrs"`
 	UsePrivateLoadBalancer           types.Bool `tfsdk:"use_private_load_balancer"`
 	UsePublicWorkerNode              types.Bool `tfsdk:"use_public_worker_node"`
+	EnablePrivateEks                 types.Bool `tfsdk:"enable_private_eks"`
 }
 
 type customRegistryOptions struct {
@@ -74,6 +75,7 @@ func (p *resourceModel) convertToCreateAwsClusterRequest() *models.CreateAwsClus
 		EnableSpotInstances:              p.getEnableSpotInstances(),
 		CustomAmiID:                      p.getCustomAmiID(),
 		ComputeInstanceTypes:             p.getComputeInstanceTypes(),
+		EnablePrivateEKS:                 p.NetworkSettings.EnablePrivateEks.ValueBoolPointer(),
 	}
 }
 

--- a/resources/dw/cluster/aws/resource_cluster_test.go
+++ b/resources/dw/cluster/aws/resource_cluster_test.go
@@ -128,6 +128,12 @@ var testDwClusterSchema = schema.Schema{
 					Required:            true,
 					MarkdownDescription: "Whether to use public IP addresses for worker nodes.",
 				},
+				"enable_private_eks": schema.BoolAttribute{
+					Optional:            true,
+					Computed:            true,
+					Default:             booldefault.StaticBool(false),
+					MarkdownDescription: "Enable private EKS API endpoint.",
+				},
 			},
 		},
 		"instance_settings": schema.SingleNestedAttribute{
@@ -226,6 +232,7 @@ func createRawClusterResource() tftypes.Value {
 						"whitelist_workload_access_ip_cidrs":    tftypes.List{ElementType: tftypes.String},
 						"use_private_load_balancer":             tftypes.Bool,
 						"use_public_worker_node":                tftypes.Bool,
+						"enable_private_eks":                    tftypes.Bool,
 					},
 				},
 				"instance_settings": tftypes.Object{
@@ -272,6 +279,7 @@ func createRawClusterResource() tftypes.Value {
 						"whitelist_workload_access_ip_cidrs":    tftypes.List{ElementType: tftypes.String},
 						"use_private_load_balancer":             tftypes.Bool,
 						"use_public_worker_node":                tftypes.Bool,
+						"enable_private_eks":                    tftypes.Bool,
 					},
 				}, map[string]tftypes.Value{
 					"worker_subnet_ids": tftypes.NewValue(tftypes.List{ElementType: tftypes.String},
@@ -301,6 +309,7 @@ func createRawClusterResource() tftypes.Value {
 						}),
 					"use_private_load_balancer": tftypes.NewValue(tftypes.Bool, true),
 					"use_public_worker_node":    tftypes.NewValue(tftypes.Bool, false),
+					"enable_private_eks":        tftypes.NewValue(tftypes.Bool, false),
 				},
 			),
 			"instance_settings": tftypes.NewValue(

--- a/resources/dw/cluster/aws/schema_cluster.go
+++ b/resources/dw/cluster/aws/schema_cluster.go
@@ -148,6 +148,12 @@ var networkSettings = map[string]schema.Attribute{
 		Required:            true,
 		MarkdownDescription: "Whether to use public IP addresses for worker nodes.",
 	},
+	"enable_private_eks": schema.BoolAttribute{
+		Optional:            true,
+		Computed:            true,
+		Default:             booldefault.StaticBool(false),
+		MarkdownDescription: "Enable private EKS API endpoint.",
+	},
 }
 
 var instanceSettings = map[string]schema.Attribute{

--- a/resources/dw/resource_dw_aws_acc_test.go
+++ b/resources/dw/resource_dw_aws_acc_test.go
@@ -237,7 +237,7 @@ func testAccAwsEnvironmentConfig(envParams *awsEnvironmentTestParameters) string
 			vpc_id = %[6]q
 			subnet_ids = [ %[7]s ]
 			create_private_subnets = true
-			create_service_endpoints = false
+			create_service_endpoints = true
 			tags = {
 			  "made-with": "CDP Terraform Provider"
 			}
@@ -285,6 +285,7 @@ func testAccAwsClusterBasicConfig(params *awsEnvironmentTestParameters) string {
 			use_overlay_network = true
 			use_private_load_balancer = true
 			use_public_worker_node = false
+			enable_private_eks = false
 		  }
           depends_on = [ cdp_datalake_aws_datalake.test_dl_dw_aws ]
 		}


### PR DESCRIPTION
The enable_private_eks option is added to the AWS DW module. With this parameter the inverting proxy endpoint is set up and the EKS API endpoint will use a private address.