### PR TITLE
Fixing e2e tests

### DIFF
--- a/resources/datalake/resource_aws_datalake_test.go
+++ b/resources/datalake/resource_aws_datalake_test.go
@@ -104,6 +104,7 @@ func TestAccAwsDataLake_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "datalake_name", dlParams.Name),
 					resource.TestCheckResourceAttrWith(resourceName, "crn", cdpacctest.CheckCrn),
 				),
+				Destroy: false,
 			},
 		},
 	})


### PR DESCRIPTION
This change temporarily disables the data lake acceptance test environment destroy. This change should be reverted