### PR TITLE
DWX-20183 Deprecate standalone default database catalog resource

### DIFF
--- a/docs/resources/dw_aws_cluster.md
+++ b/docs/resources/dw_aws_cluster.md
@@ -83,10 +83,12 @@ output "name" {
 ### Read-Only
 
 - `cluster_id` (String) The id of the cluster.
+- `default_database_catalog` (Attributes) (see [below for nested schema](#nestedatt--default_database_catalog))
 - `id` (String) The ID of this resource.
 - `last_updated` (String) Timestamp of the last Terraform update of the order.
 - `name` (String) The name of the cluster matches the environment name.
 - `status` (String) The status of the cluster.
+- `version` (String) The version of the cluster.
 
 <a id="nestedatt--network_settings"></a>
 ### Nested Schema for `network_settings`
@@ -119,7 +121,6 @@ Required:
 
 Optional:
 
-- `additional_instance_types` (List of String) The additional instance types that the environment is allowed to use, listed in their priority order. They will be used instead of the primary compute instance type in case it is unavailable. You cannot include any instance type that was already indicated in computeInstanceTypes.
 - `compute_instance_types` (List of String) The compute instance types that the environment is restricted to use. This affects the creation of virtual warehouses where this restriction will apply. Select an instance type that meets your computing, memory, networking, or storage needs. As of now, only a single instance type can be listed.
 - `custom_ami_id` (String) The custom AMI ID to use for worker nodes.
 - `enable_spot_instances` (Boolean) Whether to use spot instances for worker nodes.
@@ -133,3 +134,14 @@ Optional:
 - `async` (Boolean) Boolean value that specifies if Terraform should wait for resource creation/deletion.
 - `call_failure_threshold` (Number) Threshold value that specifies how many times should a single call failure happen before giving up the polling.
 - `polling_timeout` (Number) Timeout value in minutes that specifies for how long should the polling go for resource creation/deletion.
+
+
+<a id="nestedatt--default_database_catalog"></a>
+### Nested Schema for `default_database_catalog`
+
+Read-Only:
+
+- `id` (String) The ID of the database catalog.
+- `last_updated` (String) Timestamp of the last Terraform update of the order.
+- `name` (String) The name of the database catalog.
+- `status` (String) The status of the database catalog.

--- a/resources/dw/cluster/aws/model_cluster_test.go
+++ b/resources/dw/cluster/aws/model_cluster_test.go
@@ -13,7 +13,6 @@ package aws
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -44,7 +43,7 @@ func (s *DwClusterModelTestSuite) SetupSuite() {
 }
 
 func (s *DwClusterModelTestSuite) TestConvertToCreateAwsClusterRequest() {
-	awsCluster := s.rm.convertToCreateAwsClusterRequest()
+	awsCluster, _ := s.rm.convertToCreateAwsClusterRequest(context.TODO())
 	s.Equal("crn", *awsCluster.EnvironmentCrn)
 	s.Equal(true, awsCluster.UseOverlayNetwork)
 	s.Equal([]string{"cidr-1", "cidr-2", "cidr-3"}, awsCluster.WhitelistK8sClusterAccessIPCIDRs)
@@ -60,14 +59,4 @@ func (s *DwClusterModelTestSuite) TestConvertToCreateAwsClusterRequest() {
 	s.Equal(false, *awsCluster.EnableSpotInstances)
 	s.Equal("", awsCluster.CustomAmiID)
 	s.Equal([]string{}, awsCluster.ComputeInstanceTypes)
-}
-
-func (s *DwClusterModelTestSuite) TestGetPollingTimeout() {
-	timeout := s.rm.getPollingTimeout()
-	s.Equal(90*time.Minute, timeout)
-}
-
-func (s *DwClusterModelTestSuite) TestGetCallFailureThreshold() {
-	out := s.rm.getCallFailureThreshold()
-	s.Equal(3, out)
 }

--- a/resources/dw/cluster/aws/schema_cluster.go
+++ b/resources/dw/cluster/aws/schema_cluster.go
@@ -52,6 +52,10 @@ var dwClusterSchema = schema.Schema{
 			Computed:            true,
 			MarkdownDescription: "The status of the cluster.",
 		},
+		"version": schema.StringAttribute{
+			Computed:            true,
+			MarkdownDescription: "The version of the cluster.",
+		},
 		"node_role_cdw_managed_policy_arn": schema.StringAttribute{
 			Optional:            true,
 			MarkdownDescription: "The managed policy ARN to be attached to the created node instance role.",
@@ -83,7 +87,12 @@ var dwClusterSchema = schema.Schema{
 		},
 		"instance_settings": schema.SingleNestedAttribute{
 			Optional:   true,
+			Computed:   true,
 			Attributes: instanceSettings,
+		},
+		"default_database_catalog": schema.SingleNestedAttribute{
+			Computed:   true,
+			Attributes: defaultDatabaseCatalogProperties,
 		},
 		"polling_options": schema.SingleNestedAttribute{
 			MarkdownDescription: "Polling related configuration options that could specify various values that will be used during CDP resource creation.",
@@ -163,12 +172,27 @@ var instanceSettings = map[string]schema.Attribute{
 	},
 	"compute_instance_types": schema.ListAttribute{
 		Optional:            true,
+		Computed:            true,
 		ElementType:         types.StringType,
 		MarkdownDescription: "The compute instance types that the environment is restricted to use. This affects the creation of virtual warehouses where this restriction will apply. Select an instance type that meets your computing, memory, networking, or storage needs. As of now, only a single instance type can be listed.",
 	},
-	"additional_instance_types": schema.ListAttribute{
-		Optional:            true,
-		ElementType:         types.StringType,
-		MarkdownDescription: "The additional instance types that the environment is allowed to use, listed in their priority order. They will be used instead of the primary compute instance type in case it is unavailable. You cannot include any instance type that was already indicated in computeInstanceTypes.",
+}
+
+var defaultDatabaseCatalogProperties = map[string]schema.Attribute{
+	"id": schema.StringAttribute{
+		Computed:            true,
+		MarkdownDescription: "The ID of the database catalog.",
+	},
+	"name": schema.StringAttribute{
+		Computed:            true,
+		MarkdownDescription: "The name of the database catalog.",
+	},
+	"last_updated": schema.StringAttribute{
+		Computed:            true,
+		MarkdownDescription: "Timestamp of the last Terraform update of the order.",
+	},
+	"status": schema.StringAttribute{
+		Computed:            true,
+		MarkdownDescription: "The status of the database catalog.",
 	},
 }

--- a/resources/dw/databasecatalog/resource_catalog_test.go
+++ b/resources/dw/databasecatalog/resource_catalog_test.go
@@ -37,6 +37,8 @@ import (
 
 var testDatabaseCatalogSchema = schema.Schema{
 	MarkdownDescription: "Creates an AWS Data Warehouse database catalog.",
+	DeprecationMessage: "This resource is deprecated and will be removed in the next major release. The cluster resource " +
+		"default_database_catalog attribute will be used instead. All properties are computed, no need to specify them manually.",
 	Attributes: map[string]schema.Attribute{
 		"id": schema.StringAttribute{
 			Computed: true,

--- a/resources/dw/databasecatalog/schema_catalog.go
+++ b/resources/dw/databasecatalog/schema_catalog.go
@@ -21,6 +21,8 @@ import (
 
 var dwDefaultDatabaseCatalogSchema = schema.Schema{
 	MarkdownDescription: "Creates an AWS Data Warehouse database catalog.",
+	DeprecationMessage: "This resource is deprecated and will be removed in the next major release. The cluster resource " +
+		"default_database_catalog attribute will be used instead. All properties are computed, no need to specify them manually.",
 	Attributes: map[string]schema.Attribute{
 		"id": schema.StringAttribute{
 			Computed: true,


### PR DESCRIPTION
The default database catalog is now managed as part of the cluster since its lifecycle is inherently tied to the cluster's lifecycle. All properties are now computed. New data warehouse cluster setups should use the embedded catalog properties instead.

- deprecate the database catalog resource
- add default database catalog properties under dw aws cluster resource
- Add test fixes and acceptance test changes

Instance type properties are also computed. These values were not populated from the API before. There are default instance types that we should store in the state. The additional instance type attribute was not used, this property got dropped.