### PR TITLE
CDPCP-13938 Change tags for hive virtual warehouse tests

### DIFF
--- a/resources/dw/resource_dw_aws_acc_test.go
+++ b/resources/dw/resource_dw_aws_acc_test.go
@@ -320,7 +320,7 @@ func testAccHiveVirtualWarehouse(name string) string {
 			  availability_zone = "us-west-2a"
 			  ebs_llap_spill_gb = 300
 			  tags = {
-			    "made-with": "CDP Terraform Provider"
+			    "made-with": "CDP-Terraform-Provider"
 			  }
 			}
 		}

--- a/resources/dw/virtualwarehouse/hive/resource_hive_vw_acc_test.go
+++ b/resources/dw/virtualwarehouse/hive/resource_hive_vw_acc_test.go
@@ -98,7 +98,7 @@ func testAccHiveBasicConfig(params hiveTestParameters) string {
 			availability_zone = "us-west-2a"
 			ebs_llap_spill_gb = 300
 			tags = {
-			  owner = "cdw-terraform@cloudera.com"
+			  "made-with": "CDP-Terraform-Provider"
 			}
 		  }
 		}


### PR DESCRIPTION
The data warehouse module does not accept space characters in the tag format, this change replaces the tags. This is needed for successful e2e test runs.