### PR TITLE
CDPCP-14126 - GH action jobs are getting triggered once a PR is landed on the main even though it is not necessary

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: Test
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
GH action jobs under the _.github/workflows/test.yml_ are getting triggered even though all the jobs should've been run on the designated PR (since no direct push is allowed to the _main_ branch).

This is not just unnecessary resource usage, but since some jobs can be branch-specific (such as the commit count checker job that can be run only on branches that are not the main) this means these jobs shall fail and would confuse the readers of the repo.