### PR TITLE
Revert "CDPCP-14163 - temporarily disable DW acceptance test(s) due to product issue"

### DIFF
--- a/resources/dw/resource_dw_aws_acc_test.go
+++ b/resources/dw/resource_dw_aws_acc_test.go
@@ -123,7 +123,6 @@ func PreCheck(t *testing.T) {
 }
 
 func TestAccDwCluster_Basic(t *testing.T) {
-	t.Skip("Skipping test until CDPCP-14125 will not get resolved")
 	PreCheck(t)
 	credName := acctest.RandomWithPrefix(cdpacctest.ResourcePrefix)
 	awsProvider := cdpacctest.NewAwsProvider(os.Getenv(AwsAccessKeyID), os.Getenv(AwsSecretAccessKey), os.Getenv(AwsRegion))


### PR DESCRIPTION
Reverts cloudera/terraform-provider-cdp#221

The fix for the DW issue have been resolved and the new version is promoted to development environments. The standalone hive acceptance test was successful. The test should be enabled back. 