### PR TITLE
CDPCP-14163 Increase hive auto suspend timeout

### DIFF
--- a/resources/dw/resource_dw_aws_acc_test.go
+++ b/resources/dw/resource_dw_aws_acc_test.go
@@ -313,7 +313,7 @@ func testAccHiveVirtualWarehouse(name string) string {
 			min_group_count = 2
 			max_group_count = 5
 			disable_auto_suspend = false
-			auto_suspend_timeout_seconds = 100
+			auto_suspend_timeout_seconds = 1200
 			scale_wait_time_seconds = 230
 			max_concurrent_isolated_queries = 10
 			max_nodes_per_isolated_query = 10


### PR DESCRIPTION
During e2e testing the hive warehouse went into a Stopping state from the Starting state. Probably during the 30s of poll time the auto suspend timeout was hit and that prevented us to see the Running state of the entity. The auto suspend timeout will be set to 20 minutes and that should be enough time for a warehouse to start and the check to succeed.