### PR TITLE
CDPCP-14163 The availability zone should be selected automatically

### DIFF
--- a/resources/dw/resource_dw_aws_acc_test.go
+++ b/resources/dw/resource_dw_aws_acc_test.go
@@ -318,7 +318,6 @@ func testAccHiveVirtualWarehouse(name string) string {
 			max_concurrent_isolated_queries = 10
 			max_nodes_per_isolated_query = 10
 			aws_options = {
-			  availability_zone = "us-west-2a"
 			  ebs_llap_spill_gb = 300
 			  tags = {
 			    "made-with": "CDP-Terraform-Provider"

--- a/resources/dw/virtualwarehouse/hive/resource_hive_vw_acc_test.go
+++ b/resources/dw/virtualwarehouse/hive/resource_hive_vw_acc_test.go
@@ -90,12 +90,11 @@ func testAccHiveBasicConfig(params hiveTestParameters) string {
 		  min_group_count = 2
 		  max_group_count = 5
 		  disable_auto_suspend = false
-		  auto_suspend_timeout_seconds = 100
+		  auto_suspend_timeout_seconds = 1200
 		  scale_wait_time_seconds = 230
 		  max_concurrent_isolated_queries = 10
 		  max_nodes_per_isolated_query = 10
 		  aws_options = {
-			availability_zone = "us-west-2a"
 			ebs_llap_spill_gb = 300
 			tags = {
 			  "made-with": "CDP-Terraform-Provider"

--- a/resources/dw/virtualwarehouse/hive/resource_hive_vw_test.go
+++ b/resources/dw/virtualwarehouse/hive/resource_hive_vw_test.go
@@ -155,7 +155,6 @@ var testHiveSchema = schema.Schema{
 			Attributes: map[string]schema.Attribute{
 				"availability_zone": schema.StringAttribute{
 					Optional:            true,
-					Computed:            true,
 					MarkdownDescription: "This feature works only for AWS cluster type. An availability zone to host compute instances. If not specified, defaults to a randomly selected availability zone inferred from available subnets.",
 				},
 				"ebs_llap_spill_gb": schema.Int64Attribute{

--- a/resources/dw/virtualwarehouse/hive/schema_hive_vw.go
+++ b/resources/dw/virtualwarehouse/hive/schema_hive_vw.go
@@ -137,7 +137,6 @@ var hiveSchema = schema.Schema{
 			Attributes: map[string]schema.Attribute{
 				"availability_zone": schema.StringAttribute{
 					Optional:            true,
-					Computed:            true,
 					MarkdownDescription: "This feature works only for AWS cluster type. An availability zone to host compute instances. If not specified, defaults to a randomly selected availability zone inferred from available subnets.",
 				},
 				"ebs_llap_spill_gb": schema.Int64Attribute{


### PR DESCRIPTION
To make the accpetance test generic the availability zone should be selected automatically. This way we can run the tests in different regions too, not only in us-west-2.