### PR TITLE
CDPCP-15075: Conversion issue for Int32 and Int64 types in datahub

### DIFF
--- a/resources/datahub/schema_gcp_datahub.go
+++ b/resources/datahub/schema_gcp_datahub.go
@@ -25,7 +25,7 @@ var gcpInstanceGroupSchemaAttributes = map[string]schema.Attribute{
 		Optional: true,
 		NestedObject: schema.NestedAttributeObject{
 			Attributes: map[string]schema.Attribute{
-				"node_count": schema.Int64Attribute{
+				"node_count": schema.Int32Attribute{
 					MarkdownDescription: "The cluster node count. Has to be greater or equal than 0 and less than 100,000.",
 					Required:            true,
 				},
@@ -41,7 +41,7 @@ var gcpInstanceGroupSchemaAttributes = map[string]schema.Attribute{
 					MarkdownDescription: "The cloud provider-side instance type.",
 					Required:            true,
 				},
-				"root_volume_size": schema.Int64Attribute{
+				"root_volume_size": schema.Int32Attribute{
 					MarkdownDescription: "The size of the root volume in GB",
 					Required:            true,
 				},
@@ -55,11 +55,11 @@ var gcpInstanceGroupSchemaAttributes = map[string]schema.Attribute{
 					MarkdownDescription: "Configuration regarding the attached volume to the specific instance group.",
 					NestedObject: schema.NestedAttributeObject{
 						Attributes: map[string]schema.Attribute{
-							"volume_size": schema.Int64Attribute{
+							"volume_size": schema.Int32Attribute{
 								MarkdownDescription: "The size of the volume in GB.",
 								Required:            true,
 							},
-							"volume_count": schema.Int64Attribute{
+							"volume_count": schema.Int32Attribute{
 								MarkdownDescription: "The number of volumes to be attached.",
 								Required:            true,
 							},


### PR DESCRIPTION
https://cloudera.atlassian.net/browse/CDPCP-15075

As reported in [ENGESC-30658](https://cloudera.atlassian.net/browse/ENGESC-30658), the customer was seeing the following error when trying to deploy a COD database:

```
Cannot use attr.Value basetypes.Int32Value, only basetypes.Int64Value is supported because basetypes.Int64Type is the type in the schema
```

This issue was fixed in [CDPCP-15056](https://cloudera.atlassian.net/browse/CDPCP-15056).  However, the customer then started seeing the following:

```
│ Error: Value Conversion Error
│
│ with cdp_datahub_gcp_cluster.cloudera_yarn_only_cluster,
│ on cloudera_environment.tf line 92, in resource "cdp_datahub_gcp_cluster" "cloudera_yarn_only_cluster":
│ 92: resource "cdp_datahub_gcp_cluster" "cloudera_yarn_only_cluster" {
│
│ An unexpected error was encountered trying to convert into a Terraform
│ value. This is always an error in the provider. Please report the following
│ to the provider developer:
│
│ Cannot use attr.Value basetypes.Int32Value, only basetypes.Int64Value is
│ supported because basetypes.Int64Type is the type in the schema
```

This pull request changes the data type of some fields in `resources/datahub/schema_gcp_datahub.go` from `Int64` to `Int32`.