### PR TITLE
CDPCP-16282 complete architecture attribute for AWS datalake resource

### DIFF
--- a/docs/resources/datalake_aws_datalake.md
+++ b/docs/resources/datalake_aws_datalake.md
@@ -84,7 +84,7 @@ output "recipes" {
 
 ### Optional
 
-- `architecture` (String) Specifies the CPU architecture of the data lake cluster. Values are ARM64, X86_64.
+- `architecture` (String) Specifies the CPU architecture of the data lake cluster. Accepted values are `ARM64` and `X86_64`.
 - `custom_instance_groups` (Attributes Set) (see [below for nested schema](#nestedatt--custom_instance_groups))
 - `delete_options` (Attributes) Options for deleting the Datalake. (see [below for nested schema](#nestedatt--delete_options))
 - `enable_ranger_raz` (Boolean)

--- a/resources/datalake/schema_aws_datalake.go
+++ b/resources/datalake/schema_aws_datalake.go
@@ -11,11 +11,13 @@
 package datalake
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 
 	"github.com/cloudera/terraform-provider-cdp/utils"
 )
@@ -49,7 +51,11 @@ func getAwsResourceSchema() schema.Schema {
 		},
 		"architecture": schema.StringAttribute{
 			Optional:            true,
-			MarkdownDescription: "Specifies the CPU architecture of the data lake cluster. Values are ARM64, X86_64.",
+			Computed:            false,
+			MarkdownDescription: "Specifies the CPU architecture of the data lake cluster. Accepted values are `ARM64` and `X86_64`.",
+			Validators: []validator.String{
+				stringvalidator.OneOf("ARM64", "X86_64"),
+			},
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.UseStateForUnknown(),
 			},

--- a/resources/datalake/schema_aws_datalake_test.go
+++ b/resources/datalake/schema_aws_datalake_test.go
@@ -47,6 +47,13 @@ func TestAwsSpecificElements(t *testing.T) {
 			Required:      true,
 			AttributeType: schema.StringAttribute{},
 		},
+		{
+			Name:          "'architecture' should exist",
+			Field:         "architecture",
+			Computed:      false,
+			Required:      false,
+			AttributeType: schema.StringAttribute{},
+		},
 	}
 
 	test.PerformResourceSchemaValidation(t, createFilledAwsTestObject(), cases)

--- a/resources/environments/schema_aws_environment.go
+++ b/resources/environments/schema_aws_environment.go
@@ -398,6 +398,7 @@ func ToAwsEnvironmentRequest(ctx context.Context, model *awsEnvironmentResourceM
 			InstanceType:         trans.InstanceType,
 			MultiAz:              trans.MultiAz,
 			Recipes:              trans.Recipes,
+			Architecture:         trans.Architecture,
 		}
 		req.Image = img
 	}


### PR DESCRIPTION
Add Computed: true and a stringvalidator.OneOf("ARM64", "X86_64") validator to the architecture schema attribute in the cdp_datalake_aws_datalake resource.